### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Forge will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-04-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Forge will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+---
+
 ## [0.5.0] - 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "forge-lang"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "ariadne",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-lang"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Forge — Internet-native programming language with natural syntax, bytecode VM, and built-in HTTP/database/crypto"


### PR DESCRIPTION
## Summary

Release candidate for v0.5.0. Version bump + CHANGELOG date stamp only — no code changes.

### What ships in v0.5.0 (since v0.4.3)

**Security**
- HTTP SSRF/scheme/redirect/size hardening with DNS-rebinding defence
- JWT `alg=none` rejection + algorithm pinning (key-confusion defence)
- PostgreSQL TLS-by-default
- Filesystem `FORGE_FS_BASE` confinement
- IPv4-mapped IPv6 bypass fix
- `crypto.random_bytes` upgraded to `getrandom` CSPRNG

**Added**
- `db.begin`/`commit`/`rollback` + `pg.begin`/`commit`/`rollback`
- VM source-line stack traces
- `http.download`/`http.crawl` user options (timeout, max_redirects, max_bytes)
- 74+ new unit tests (crypto, regex, json, time, JWT, HTTP client)

**Fixed**
- 2 production-path `unwrap()` calls eliminated
- VM silently dropping `must`/`ask`/`await`/`freeze`/`spawn`
- LSP malformed responses for unknown methods
- PG raw-pointer client extraction replaced with safe `Arc::clone`

## Verification

- [x] 811 cargo tests pass
- [x] `forge --version` shows `forge 0.5.0`
- [x] `forge run examples/hello.fg` passes
- [x] `forge run examples/functional.fg` passes
- [x] `cargo clean -p forge-lang && cargo build` succeeds

## After merge

- Tag `v0.5.0` on the merge commit
- Create GitHub release with binaries
- Update Homebrew formula SHA256
- Update `docs/index.html` version string
