### PR TITLE
feat: LSP type-check diagnostics with line numbers

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -46,24 +46,27 @@ Already changed to `let _ = obj;`. No further work needed.
 
 **Goal:** Make Forge pleasant to write real programs in. The LSP is the highest-leverage item because every editor user benefits without changing the language.
 
-### 1.1 LSP: go-to-definition
+### ~~1.1 LSP: go-to-definition~~ ✅ DONE (PR #7)
 
-- **Where:** `src/lsp/mod.rs`
-- **What:** Resolve symbol under cursor to its definition location. Requires building a symbol table from the AST (variable bindings, function definitions, imports).
-- **Depends on:** A `SymbolTable` struct that maps `(name, scope)` → `(file, line, col)`.
+Deep go-to-definition finds top-level symbols, function params, local variables, for-loop
+vars, catch vars, and impl block methods via `collect_all_symbols`.
 
-### 1.2 LSP: find-references
+### ~~1.2 LSP: find-references~~ ✅ DONE (PR #7)
 
-- **What:** Inverse of go-to-definition. Given a definition, find all uses. Same symbol table, walked in reverse.
+`textDocument/references` with word-boundary matching. Single-file for now.
 
-### 1.3 LSP: real diagnostics
+### ~~1.3 LSP: real diagnostics~~ ✅ DONE (PR #8)
 
-- **What:** Run the parser + type checker on every `textDocument/didChange` and push diagnostics. Currently the LSP only does basic syntax errors.
-- **Depends on:** Parser producing span-annotated AST nodes (partially done — check `Span` coverage).
+Type checker wired into `get_diagnostics` — runs on every didOpen/didChange. Surfaces
+type mismatches, arity errors, return type mismatches as warnings with line numbers.
+Source tagged as `forge-typecheck`.
 
-### 1.4 LSP: hover + signature help
+### ~~1.4 LSP: hover + signature help~~ ✅ DONE (PR #7)
 
-- **What:** Show type/doc info on hover. Show function parameter hints while typing. Requires the symbol table from 1.1 + type info from the type checker.
+Hover shows full signatures for user-defined functions, variables (with mutability/type),
+structs (with fields), types (with variants), interfaces (with methods). Recursively
+walks into function bodies and impl blocks. Context-aware module completions filter
+to the specific module typed before the dot.
 
 ### 1.5 Error messages with source spans
 
@@ -191,4 +194,4 @@ Each phase is independent. When picking up work:
 5. After each item: `cargo test`, atomic commit, update CHANGELOG
 6. After each phase: cut a release
 
-Current status: **Phase 0 — items 0.1-0.4 complete, 0.5 (v0.5.0 release cut) remaining**
+Current status: **Phase 1 — items 1.1-1.4 complete. Next: 1.5 (spans), then 1.6-1.8 (fmt, doc, REPL)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **LSP hover for user-defined symbols** — functions show full signature, variables show mutability/type, structs show fields, types show variants, interfaces show methods
 - **LSP deep go-to-definition** — finds function parameters, local variables, for-loop vars, catch vars, and impl block methods — not just top-level symbols
 - **LSP context-aware module completions** — typing `math.` now only shows `math` module members instead of all 200+ members from every module
+- **LSP type-check diagnostics** — the gradual type checker now runs on every edit, surfacing type mismatches, arity errors, and return type mismatches as editor warnings with line numbers
 
 ---
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -241,17 +241,19 @@ fn get_diagnostics(source: &str) -> Vec<serde_json::Value> {
     let mut parser = crate::parser::Parser::new(tokens);
     match parser.parse_program() {
         Ok(program) => {
+            let source_lines: Vec<&str> = source.lines().collect();
             let mut checker = crate::typechecker::TypeChecker::with_strict(false);
             let warnings = checker.check(&program);
             warnings
                 .into_iter()
                 .map(|w| {
                     let line = w.line.saturating_sub(1);
+                    let end_char = source_lines.get(line).map(|l| l.len()).unwrap_or(0);
                     let severity = if w.is_error { 1 } else { 2 };
                     serde_json::json!({
                         "range": {
                             "start": {"line": line, "character": 0},
-                            "end": {"line": line, "character": 0}
+                            "end": {"line": line, "character": end_char}
                         },
                         "severity": severity,
                         "source": "forge-typecheck",

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -240,7 +240,26 @@ fn get_diagnostics(source: &str) -> Vec<serde_json::Value> {
 
     let mut parser = crate::parser::Parser::new(tokens);
     match parser.parse_program() {
-        Ok(_) => Vec::new(),
+        Ok(program) => {
+            let mut checker = crate::typechecker::TypeChecker::with_strict(false);
+            let warnings = checker.check(&program);
+            warnings
+                .into_iter()
+                .map(|w| {
+                    let line = w.line.saturating_sub(1);
+                    let severity = if w.is_error { 1 } else { 2 };
+                    serde_json::json!({
+                        "range": {
+                            "start": {"line": line, "character": 0},
+                            "end": {"line": line, "character": 0}
+                        },
+                        "severity": severity,
+                        "source": "forge-typecheck",
+                        "message": w.message
+                    })
+                })
+                .collect()
+        }
         Err(e) => {
             vec![serde_json::json!({
                 "range": {
@@ -1513,5 +1532,50 @@ mod tests {
             );
         }
         assert!(!completions.is_empty());
+    }
+
+    #[test]
+    fn diagnostics_reports_type_warnings() {
+        let diags = get_diagnostics("let x: Int = \"hello\"");
+        assert_eq!(diags.len(), 1);
+        let msg = diags[0]
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(msg.contains("type mismatch"));
+        // Severity 2 = warning (not strict mode)
+        assert_eq!(diags[0].get("severity").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(
+            diags[0].get("source").and_then(|v| v.as_str()),
+            Some("forge-typecheck")
+        );
+    }
+
+    #[test]
+    fn diagnostics_includes_line_number() {
+        let diags = get_diagnostics("let y = 1\nlet x: Int = \"hello\"");
+        assert_eq!(diags.len(), 1);
+        // Line 2 in source (1-indexed) → line 1 in LSP (0-indexed)
+        let line = diags[0]
+            .pointer("/range/start/line")
+            .and_then(|v| v.as_u64());
+        assert_eq!(line, Some(1));
+    }
+
+    #[test]
+    fn diagnostics_empty_for_valid_code() {
+        let diags = get_diagnostics("let x = 42\nlet y = x + 1");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn diagnostics_reports_arity_mismatch() {
+        let diags = get_diagnostics("fn add(a, b) { return a + b }\nadd(1, 2, 3)");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0]
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .contains("expects 2"));
     }
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -219,6 +219,10 @@ impl TypeChecker {
         for spanned in &program.statements {
             self.collect_definitions(&spanned.stmt);
         }
+        // Note: current_line only updates for top-level SpannedStmt. Warnings inside
+        // function bodies inherit the parent function's line because body: Vec<Stmt>
+        // has no span info. This is an AST limitation — fixing it requires making
+        // inner statements Spanned (tracked as roadmap item 1.5).
         for spanned in &program.statements {
             self.current_line = spanned.line;
             self.check_stmt(&spanned.stmt);

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -43,6 +43,7 @@ pub struct TypeChecker {
     structs: HashMap<String, Vec<String>>,
     variables: HashMap<String, InferredType>,
     current_fn_return: Option<InferredType>,
+    current_line: usize,
     strict: bool,
     warnings: Vec<TypeWarning>,
 }
@@ -184,6 +185,7 @@ impl TypeChecker {
             structs: HashMap::new(),
             variables: HashMap::new(),
             current_fn_return: None,
+            current_line: 0,
             strict: false,
             warnings: Vec::new(),
         }
@@ -197,17 +199,20 @@ impl TypeChecker {
             structs: HashMap::new(),
             variables: HashMap::new(),
             current_fn_return: None,
+            current_line: 0,
             strict,
             warnings: Vec::new(),
         }
     }
 
     fn emit(&mut self, msg: impl Into<String>) {
-        if self.strict {
-            self.warnings.push(TypeWarning::error(msg));
+        let mut warning = if self.strict {
+            TypeWarning::error(msg)
         } else {
-            self.warnings.push(TypeWarning::warn(msg));
-        }
+            TypeWarning::warn(msg)
+        };
+        warning.line = self.current_line;
+        self.warnings.push(warning);
     }
 
     pub fn check(&mut self, program: &Program) -> Vec<TypeWarning> {
@@ -215,6 +220,7 @@ impl TypeChecker {
             self.collect_definitions(&spanned.stmt);
         }
         for spanned in &program.statements {
+            self.current_line = spanned.line;
             self.check_stmt(&spanned.stmt);
         }
         std::mem::take(&mut self.warnings)


### PR DESCRIPTION
## Summary

- Wire the gradual type checker into `get_diagnostics` so it runs on every `didOpen`/`didChange`
- Add `current_line` tracking to `TypeChecker` so warnings carry real source line numbers (previously always 0)
- Type mismatches, arity errors, and return type mismatches surface as editor warnings tagged `forge-typecheck`
- Update roadmap: Phase 1 items 1.1–1.4 now complete

## Test plan

- [x] 824 cargo tests pass (18 LSP-specific, 4 new)
- [x] `forge run examples/hello.fg` passes
- [x] `forge run examples/functional.fg` passes
- [ ] Manual: open a `.fg` file with type annotations in VS Code, verify warnings appear inline