### PR TITLE
feat: Phase 2 — package ecosystem improvements

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,31 +106,24 @@ Implemented `extract_preceding_comments` using `SpannedStmt.line` to capture
 
 **Goal:** Enable multi-file, multi-author Forge projects. This is what turns Forge from a scripting tool into a language people build real things with.
 
-### 2.1 `forge.toml` project manifest
+### ~~2.1 `forge.toml` project manifest~~ ✅ DONE (pre-existing)
 
-- **What:** Define project name, version, entry point, dependencies. Minimal spec:
+Already implemented in `src/manifest.rs`: `Manifest`, `ProjectConfig`, `DependencySpec`
+(version/git/path/branch), `TestConfig`, `Lockfile`, `LockedPackage`. 10 tests.
+`forge run` now reads `entry` from `forge.toml` when no file argument is given.
 
-  ```toml
-  [package]
-  name = "my-app"
-  version = "0.1.0"
-  entry = "src/main.fg"
+### ~~2.2 Module resolution across packages~~ ✅ DONE
 
-  [dependencies]
-  http-utils = "0.2"
-  ```
+`resolve_import_from()` resolves relative to the importing file's directory first,
+then falls back to CWD-relative, `forge_modules/`, and `.forge/packages/`. The interpreter
+tracks `source_file` and passes the base directory to the resolver. Wildcard imports
+now copy struct defs, type defs, and impl block methods alongside functions and variables.
 
-- **Where:** New `src/manifest.rs` or `src/package.rs` (already exists for scaffolding — extend it).
+### ~~2.3 `forge install <pkg>`~~ ✅ DONE (pre-existing)
 
-### 2.2 Module resolution across packages
-
-- **Where:** `src/interpreter/mod.rs` (import resolution), `src/parser/parser.rs` (import statements)
-- **What:** `import "http-utils"` resolves to `~/.forge/packages/http-utils/src/mod.fg` (or similar). Define the resolution algorithm: local → project deps → global.
-
-### 2.3 `forge install <pkg>`
-
-- **What:** Fetch a package from a git repo (initially) or a registry (later). Write it to a local `forge_packages/` directory. Update a lock file.
-- **Note:** Start with git-based packages. A central registry is a Phase 3+ concern.
+Already implemented in `src/package.rs`: `install()` handles git URLs, local paths,
+and registry sources. `install_from_manifest()` reads `forge.toml` dependencies,
+installs to `forge_modules/`, manages `forge.lock`. 4 tests.
 
 ### 2.4 `forge publish`
 
@@ -199,4 +192,4 @@ Each phase is independent. When picking up work:
 5. After each item: `cargo test`, atomic commit, update CHANGELOG
 6. After each phase: cut a release
 
-Current status: **Phase 1 — items 1.1-1.4, 1.6-1.8 complete. Remaining: 1.5 (source spans — deferred, biggest item). Ready for Phase 2.**
+Current status: **Phase 2 — items 2.1-2.3 complete. Remaining: 2.4 (publish — deferred until registry exists). Phase 1 item 1.5 (source spans) also deferred. Ready for Phase 3.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`forge doc` variable extraction** — `let`/`let mut` declarations now appear in doc output (previously silently skipped)
 - **`forge doc` comment extraction** — `//` comments preceding functions, structs, and variables are now captured and displayed
 - **`forge fmt` paren continuation** — multi-line function calls with open parens now auto-indent correctly (previously only braces and brackets were tracked)
+- **`forge run` with manifest entry** — `forge run` without a file argument now reads the `entry` field from `forge.toml`, enabling project-level `forge run` workflows
+- **Relative import resolution** — `import "helper"` now resolves relative to the importing file's directory first, then falls back to CWD and `forge_modules/`. Enables packages with internal imports.
+- **Import struct/type/impl definitions** — wildcard imports (`import "lib"`) now copy struct definitions, type definitions, and impl block methods in addition to functions and variables
 
 ---
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1215,24 +1215,54 @@ impl Interpreter {
                     // Import all top-level definitions
                     for spanned in &program.statements {
                         match &spanned.stmt {
-                            Stmt::FnDef { name, .. }
-                            | Stmt::Let { name, .. }
-                            | Stmt::StructDef { name, .. }
-                            | Stmt::TypeDef { name, .. } => {
+                            Stmt::FnDef { name, .. } | Stmt::Let { name, .. } => {
                                 if let Some(val) = import_interp.env.get(name) {
                                     self.env.define(name.clone(), val);
                                 }
                             }
-                            Stmt::ImplBlock {
-                                type_name, methods, ..
-                            } => {
-                                // Import methods defined in impl blocks
-                                for method in methods {
-                                    if let Stmt::FnDef { name, .. } = method {
-                                        let qualified = format!("{}::{}", type_name, name);
-                                        if let Some(val) = import_interp.env.get(&qualified) {
-                                            self.env.define(qualified, val);
-                                        }
+                            Stmt::StructDef { name, .. } => {
+                                if let Some(val) = import_interp.env.get(name) {
+                                    self.env.define(name.clone(), val);
+                                }
+                                // Copy struct defaults and embedded fields
+                                if let Some(defaults) = import_interp.struct_defaults.get(name) {
+                                    self.struct_defaults.insert(name.clone(), defaults.clone());
+                                }
+                                if let Some(embeds) = import_interp.embedded_fields.get(name) {
+                                    self.embedded_fields.insert(name.clone(), embeds.clone());
+                                }
+                            }
+                            Stmt::TypeDef { name, variants } => {
+                                // Import each variant individually
+                                for variant in variants {
+                                    if let Some(val) = import_interp.env.get(&variant.name) {
+                                        self.env.define(variant.name.clone(), val);
+                                    }
+                                }
+                                // Import type metadata
+                                let meta_key = format!("__type_{}__", name);
+                                if let Some(val) = import_interp.env.get(&meta_key) {
+                                    self.env.define(meta_key, val);
+                                }
+                            }
+                            Stmt::ImplBlock { type_name, .. } => {
+                                // Copy method tables and static methods
+                                if let Some(methods) = import_interp.method_tables.get(type_name) {
+                                    let entry = self
+                                        .method_tables
+                                        .entry(type_name.clone())
+                                        .or_insert_with(IndexMap::new);
+                                    for (k, v) in methods {
+                                        entry.insert(k.clone(), v.clone());
+                                    }
+                                }
+                                if let Some(statics) = import_interp.static_methods.get(type_name) {
+                                    let entry = self
+                                        .static_methods
+                                        .entry(type_name.clone())
+                                        .or_insert_with(IndexMap::new);
+                                    for (k, v) in statics {
+                                        entry.insert(k.clone(), v.clone());
                                     }
                                 }
                             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -364,6 +364,8 @@ pub struct Interpreter {
     pub current_line: usize,
     /// Source code (for error display)
     pub source: Option<String>,
+    /// Path of the currently executing source file (for relative imports)
+    pub source_file: Option<std::path::PathBuf>,
 }
 
 impl Interpreter {
@@ -379,6 +381,7 @@ impl Interpreter {
             struct_defaults: HashMap::new(),
             current_line: 0,
             source: None,
+            source_file: None,
         };
         interp.register_builtins();
         interp
@@ -397,6 +400,7 @@ impl Interpreter {
         interp.struct_defaults = self.struct_defaults.clone();
         interp.current_line = self.current_line;
         interp.source = self.source.clone();
+        interp.source_file = self.source_file.clone();
         interp
     }
 
@@ -1172,7 +1176,12 @@ impl Interpreter {
                     )));
                 }
 
-                let file_path = match crate::package::resolve_import(path) {
+                let base_dir = self
+                    .source_file
+                    .as_ref()
+                    .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+                let file_path = match crate::package::resolve_import_from(path, base_dir.as_deref())
+                {
                     Some(p) => p,
                     None => {
                         return Err(RuntimeError::new(&format!(
@@ -1193,6 +1202,7 @@ impl Interpreter {
                 })?;
 
                 let mut import_interp = Interpreter::new();
+                import_interp.source_file = Some(file_path.clone());
                 import_interp.run(&program)?;
 
                 if let Some(name_list) = names {
@@ -1203,12 +1213,27 @@ impl Interpreter {
                     }
                 } else {
                     // Import all top-level definitions
-                    // We check what the import interpreter defined beyond builtins
                     for spanned in &program.statements {
                         match &spanned.stmt {
-                            Stmt::FnDef { name, .. } | Stmt::Let { name, .. } => {
+                            Stmt::FnDef { name, .. }
+                            | Stmt::Let { name, .. }
+                            | Stmt::StructDef { name, .. }
+                            | Stmt::TypeDef { name, .. } => {
                                 if let Some(val) = import_interp.env.get(name) {
                                     self.env.define(name.clone(), val);
+                                }
+                            }
+                            Stmt::ImplBlock {
+                                type_name, methods, ..
+                            } => {
+                                // Import methods defined in impl blocks
+                                for method in methods {
+                                    if let Stmt::FnDef { name, .. } = method {
+                                        let qualified = format!("{}::{}", type_name, name);
+                                        if let Some(val) = import_interp.env.get(&qualified) {
+                                            self.env.define(qualified, val);
+                                        }
+                                    }
                                 }
                             }
                             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,15 @@ async fn main() {
                 Some(f) => f,
                 None => {
                     if let Some(m) = manifest::load_manifest() {
+                        if m.project.entry.is_empty() {
+                            eprintln!(
+                                "{}",
+                                errors::format_simple_error(
+                                    "forge.toml found but no 'entry' field set. Add entry = \"src/main.fg\" to [project] or specify a file: forge run <file>"
+                                )
+                            );
+                            process::exit(1);
+                        }
                         PathBuf::from(&m.project.entry)
                     } else {
                         eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,8 @@ struct Cli {
 enum Command {
     /// Run a Forge source file (.fg) or compiled bytecode (.fgc)
     Run {
-        /// Path to a .fg or .fgc file
-        file: PathBuf,
+        /// Path to a .fg or .fgc file (reads entry from forge.toml if omitted)
+        file: Option<PathBuf>,
     },
     /// Start the interactive REPL
     Repl,
@@ -177,6 +177,22 @@ async fn main() {
 
     match cli.command {
         Some(Command::Run { file }) => {
+            let file = match file {
+                Some(f) => f,
+                None => {
+                    if let Some(m) = manifest::load_manifest() {
+                        PathBuf::from(&m.project.entry)
+                    } else {
+                        eprintln!(
+                            "{}",
+                            errors::format_simple_error(
+                                "no file specified and no forge.toml found. Usage: forge run <file>"
+                            )
+                        );
+                        process::exit(1);
+                    }
+                }
+            };
             if file.extension().map(|e| e == "fgc").unwrap_or(false) {
                 run_bytecode_file(&file, profile);
                 return;
@@ -615,6 +631,10 @@ async fn run_source(source: &str, filename: &str, use_vm: bool, profile: bool, s
     } else {
         let mut interpreter = Interpreter::new();
         interpreter.source = Some(source.to_string());
+        let path = std::path::Path::new(filename);
+        if path.exists() {
+            interpreter.source_file = Some(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
+        }
         interpreter.set_defer_host_runtime(true);
         match interpreter.run(&program) {
             Ok(_) => {}

--- a/src/package.rs
+++ b/src/package.rs
@@ -353,9 +353,29 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Resolve an import path, checking forge_modules/ and .forge/packages/
+/// Resolve an import path, checking relative to the importing file first,
+/// then forge_modules/ and .forge/packages/.
+///
+/// `base_dir` is the directory of the file containing the import statement.
+/// When `None`, only CWD-relative and package paths are checked.
 pub fn resolve_import(path: &str) -> Option<PathBuf> {
-    // Direct file path
+    resolve_import_from(path, None)
+}
+
+pub fn resolve_import_from(path: &str, base_dir: Option<&Path>) -> Option<PathBuf> {
+    // If a base directory is provided, check relative to it first
+    if let Some(base) = base_dir {
+        let relative = base.join(path);
+        if relative.exists() {
+            return Some(relative);
+        }
+        let relative_fg = base.join(format!("{}.fg", path));
+        if relative_fg.exists() {
+            return Some(relative_fg);
+        }
+    }
+
+    // Direct file path (CWD-relative)
     let direct = Path::new(path);
     if direct.exists() {
         return Some(direct.to_path_buf());
@@ -486,6 +506,37 @@ toolkit = "1.2.3"
         let package = lockfile.find("toolkit").unwrap();
         assert_eq!(package.version, "1.2.3");
         assert!(package.source.starts_with("registry+"));
+
+        std::fs::remove_dir_all(&workspace).unwrap();
+    }
+
+    #[test]
+    fn resolve_import_from_checks_base_dir_first() {
+        let workspace = temp_path("resolve");
+        let subdir = workspace.join("lib");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join("helper.fg"), "let x = 1").unwrap();
+
+        // Without base_dir, won't find it (not in CWD or forge_modules)
+        assert!(resolve_import_from("helper", None).is_none());
+
+        // With base_dir pointing to the lib/ directory, finds it
+        let result = resolve_import_from("helper", Some(&subdir));
+        assert!(result.is_some());
+        assert!(result.unwrap().ends_with("helper.fg"));
+
+        std::fs::remove_dir_all(&workspace).unwrap();
+    }
+
+    #[test]
+    fn resolve_import_from_falls_back_to_packages() {
+        let workspace = temp_path("fallback");
+        let base = workspace.join("src");
+        std::fs::create_dir_all(&base).unwrap();
+
+        // Even with a base_dir, should still fall back to CWD-relative checks
+        let result = resolve_import_from("nonexistent_pkg", Some(&base));
+        assert!(result.is_none());
 
         std::fs::remove_dir_all(&workspace).unwrap();
     }


### PR DESCRIPTION
## Summary

- **forge run with manifest entry** — running forge run without a file argument now reads the entry field from forge.toml, enabling project-level workflows without specifying the entry file every time
- **Relative import resolution** — import helper now resolves relative to the importing files directory first, then falls back to CWD and forge_modules/. This enables packages with internal imports that reference sibling files.
- **Full definition imports** — wildcard imports now copy struct definitions, type definitions, and impl block methods in addition to functions and variables (previously only FnDef and Let were imported)

## What was already built

Phase 2 items 2.1 (manifest) and 2.3 (install) were already largely implemented in manifest.rs and package.rs. This PR fills the gaps in 2.2 (cross-package module resolution) and wires forge run to the manifest.

## Test plan

- [x] 828 cargo tests pass (2 new tests for resolve_import_from)
- [x] forge run examples/hello.fg and examples/functional.fg pass
- [ ] Test forge run in a directory with forge.toml containing an entry field
- [ ] Test cross-file imports where the imported file itself imports a sibling