### PR TITLE
feat: source spans — line-accurate runtime errors (Phase 1.5)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -68,11 +68,14 @@ structs (with fields), types (with variants), interfaces (with methods). Recursi
 walks into function bodies and impl blocks. Context-aware module completions filter
 to the specific module typed before the dot.
 
-### 1.5 Error messages with source spans
+### ~~1.5 Error messages with source spans~~ ✅ DONE
 
-- **Where:** `src/errors.rs`, `src/interpreter/mod.rs`, `src/parser/parser.rs`
-- **What:** Rust-style error messages with source snippets, underline carets, and context. Currently errors are just strings. This is a cross-cutting change: parser errors, type errors, and runtime errors all need span info threaded through.
-- **Note:** This is the biggest item in Phase 1. Consider doing it early since 1.1-1.4 depend on good span coverage.
+Changed all `Vec<Stmt>` body fields in the AST to `Vec<SpannedStmt>` with line+col.
+Parser now wraps every inner statement with position from the token stream.
+`exec_stmts` patches `RuntimeError.line` from `SpannedStmt` on bubble-up.
+Runtime errors now show exact source line with ariadne snippets and carets.
+`RuntimeError` gained `col` field (ready for expression-level spans in future).
+8 files changed across parser, interpreter, VM compiler, type checker, LSP.
 
 ### ~~1.6 `forge fmt` — paren continuation~~ ✅ DONE (PR #9)
 
@@ -192,4 +195,4 @@ Each phase is independent. When picking up work:
 5. After each item: `cargo test`, atomic commit, update CHANGELOG
 6. After each phase: cut a release
 
-Current status: **Phase 2 — items 2.1-2.3 complete. Remaining: 2.4 (publish — deferred until registry exists). Phase 1 item 1.5 (source spans) also deferred. Ready for Phase 3.**
+Current status: **Phase 1 complete (all items including 1.5). Phase 2 items 2.1-2.3 complete. Remaining: 2.4 (publish — deferred until registry exists). Ready for Phase 3.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`forge run` with manifest entry** — `forge run` without a file argument now reads the `entry` field from `forge.toml`, enabling project-level `forge run` workflows
 - **Relative import resolution** — `import "helper"` now resolves relative to the importing file's directory first, then falls back to CWD and `forge_modules/`. Enables packages with internal imports.
 - **Import struct/type/impl definitions** — wildcard imports (`import "lib"`) now copy struct definitions, type definitions, and impl block methods in addition to functions and variables
+- **Source spans in AST** — all inner statement bodies (`if`, `for`, `while`, `fn`, `match`, `try/catch`, etc.) now carry per-statement line and column info via `SpannedStmt`. Runtime errors report the exact source line, even inside deeply nested blocks.
+- **Line-accurate runtime errors** — errors inside nested blocks now show the correct inner line with source snippets via ariadne, instead of pointing at the top-level statement
 
 ---
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,13 +28,13 @@ pub enum Value {
     Function {
         name: String,
         params: Vec<Param>,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
         closure: Environment,
         decorators: Vec<Decorator>,
     },
     Lambda {
         params: Vec<Param>,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
         closure: Arc<std::sync::Mutex<Environment>>,
     },
     ResultOk(Box<Value>),
@@ -404,7 +404,10 @@ impl Interpreter {
         interp
     }
 
-    pub(crate) fn exec_background_block(&mut self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
+    pub(crate) fn exec_background_block(
+        &mut self,
+        stmts: &[SpannedStmt],
+    ) -> Result<(), RuntimeError> {
         let _ = self.exec_block(stmts)?;
         Ok(())
     }
@@ -867,7 +870,7 @@ impl Interpreter {
             } => {
                 // Phase 4 will fully implement method tables + dispatch
                 // For now, register each method function in the environment
-                for method_stmt in methods {
+                for method_spanned in methods {
                     if let Stmt::FnDef {
                         name: method_name,
                         params,
@@ -875,7 +878,7 @@ impl Interpreter {
                         body,
                         is_async,
                         ..
-                    } = method_stmt
+                    } = &method_spanned.stmt
                     {
                         let has_receiver = params.first().map_or(false, |p| p.name == "it");
                         let qualified_name = if has_receiver {
@@ -1529,17 +1532,19 @@ impl Interpreter {
         }
     }
 
-    fn exec_block(&mut self, stmts: &[Stmt]) -> Result<Signal, RuntimeError> {
+    fn exec_block(&mut self, stmts: &[SpannedStmt]) -> Result<Signal, RuntimeError> {
         self.env.push_scope();
         let result = self.exec_stmts(stmts);
         self.env.pop_scope();
         result
     }
 
-    fn exec_stmts(&mut self, stmts: &[Stmt]) -> Result<Signal, RuntimeError> {
+    fn exec_stmts(&mut self, stmts: &[SpannedStmt]) -> Result<Signal, RuntimeError> {
         let mut result = Signal::None;
         let mut last_expr_value = Value::Null;
-        for stmt in stmts {
+        for s in stmts {
+            self.current_line = s.line;
+            let stmt = &s.stmt;
             if let Stmt::Expression(expr) = stmt {
                 last_expr_value = self.eval_expr(expr)?;
                 continue;
@@ -2198,7 +2203,9 @@ impl Interpreter {
             Expr::Block(stmts) => {
                 self.env.push_scope();
                 let mut last = Value::Null;
-                for stmt in stmts {
+                for spanned in stmts {
+                    self.current_line = spanned.line;
+                    let stmt = &spanned.stmt;
                     match stmt {
                         Stmt::If {
                             condition,
@@ -2214,11 +2221,12 @@ impl Interpreter {
                                 &vec![]
                             };
                             for s in branch {
-                                if let Signal::Return(v) = self.exec_stmt(s)? {
+                                self.current_line = s.line;
+                                if let Signal::Return(v) = self.exec_stmt(&s.stmt)? {
                                     self.env.pop_scope();
                                     return Ok(v);
                                 }
-                                if let Stmt::Expression(e) = s {
+                                if let Stmt::Expression(e) = &s.stmt {
                                     last = self.eval_expr(e)?;
                                 }
                             }
@@ -2756,7 +2764,7 @@ impl Interpreter {
     }
 
     /// Spawn a block as a concurrent task, returning a TaskHandle.
-    fn spawn_task(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
+    fn spawn_task(&mut self, body: &[SpannedStmt]) -> Result<Value, RuntimeError> {
         let body = body.to_vec();
         let result_slot: Arc<(std::sync::Mutex<Option<Value>>, std::sync::Condvar)> =
             Arc::new((std::sync::Mutex::new(None), std::sync::Condvar::new()));
@@ -2973,6 +2981,7 @@ fn json_to_value(v: serde_json::Value) -> Value {
 pub struct RuntimeError {
     pub message: String,
     pub line: usize,
+    pub col: usize,
     propagated: Option<Value>,
 }
 
@@ -2981,6 +2990,7 @@ impl RuntimeError {
         Self {
             message: msg.to_string(),
             line: 0,
+            col: 0,
             propagated: None,
         }
     }
@@ -2993,6 +3003,7 @@ impl RuntimeError {
         Self {
             message,
             line: 0,
+            col: 0,
             propagated: Some(value),
         }
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1546,11 +1546,21 @@ impl Interpreter {
             self.current_line = s.line;
             let stmt = &s.stmt;
             if let Stmt::Expression(expr) = stmt {
-                last_expr_value = self.eval_expr(expr)?;
+                last_expr_value = self.eval_expr(expr).map_err(|mut e| {
+                    if e.line == 0 {
+                        e.line = s.line;
+                    }
+                    e
+                })?;
                 continue;
             }
             last_expr_value = Value::Null;
-            result = self.exec_stmt(stmt)?;
+            result = self.exec_stmt(stmt).map_err(|mut e| {
+                if e.line == 0 {
+                    e.line = s.line;
+                }
+                e
+            })?;
             match &result {
                 Signal::Return(_) | Signal::Break | Signal::Continue => break,
                 Signal::None | Signal::ImplicitReturn(_) => {}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -617,6 +617,7 @@ impl Interpreter {
                 Err(mut e) => {
                     if e.line == 0 {
                         e.line = spanned.line;
+                        e.col = spanned.col;
                     }
                     return Err(e);
                 }
@@ -630,7 +631,13 @@ impl Interpreter {
         let mut last = Value::Null;
         for spanned in &program.statements {
             self.current_line = spanned.line;
-            match self.exec_stmt(&spanned.stmt)? {
+            match self.exec_stmt(&spanned.stmt).map_err(|mut e| {
+                if e.line == 0 {
+                    e.line = spanned.line;
+                    e.col = spanned.col;
+                }
+                e
+            })? {
                 Signal::Return(v) => return Ok(v),
                 Signal::Break => return Err(RuntimeError::new("break outside of loop")),
                 Signal::Continue => return Err(RuntimeError::new("continue outside of loop")),
@@ -1549,6 +1556,7 @@ impl Interpreter {
                 last_expr_value = self.eval_expr(expr).map_err(|mut e| {
                     if e.line == 0 {
                         e.line = s.line;
+                        e.col = s.col;
                     }
                     e
                 })?;
@@ -1558,6 +1566,7 @@ impl Interpreter {
             result = self.exec_stmt(stmt).map_err(|mut e| {
                 if e.line == 0 {
                     e.line = s.line;
+                    e.col = s.col;
                 }
                 e
             })?;
@@ -2213,6 +2222,13 @@ impl Interpreter {
             Expr::Block(stmts) => {
                 self.env.push_scope();
                 let mut last = Value::Null;
+                let patch_err = |mut e: RuntimeError, s: &SpannedStmt| -> RuntimeError {
+                    if e.line == 0 {
+                        e.line = s.line;
+                        e.col = s.col;
+                    }
+                    e
+                };
                 for spanned in stmts {
                     self.current_line = spanned.line;
                     let stmt = &spanned.stmt;
@@ -2222,7 +2238,9 @@ impl Interpreter {
                             then_body,
                             else_body,
                         } => {
-                            let cond = self.eval_expr(condition)?;
+                            let cond = self
+                                .eval_expr(condition)
+                                .map_err(|e| patch_err(e, spanned))?;
                             let branch = if cond.is_truthy() {
                                 then_body
                             } else if let Some(eb) = else_body {
@@ -2232,16 +2250,18 @@ impl Interpreter {
                             };
                             for s in branch {
                                 self.current_line = s.line;
-                                if let Signal::Return(v) = self.exec_stmt(&s.stmt)? {
+                                if let Signal::Return(v) =
+                                    self.exec_stmt(&s.stmt).map_err(|e| patch_err(e, s))?
+                                {
                                     self.env.pop_scope();
                                     return Ok(v);
                                 }
                                 if let Stmt::Expression(e) = &s.stmt {
-                                    last = self.eval_expr(e)?;
+                                    last = self.eval_expr(e).map_err(|e| patch_err(e, s))?;
                                 }
                             }
                         }
-                        _ => match self.exec_stmt(stmt)? {
+                        _ => match self.exec_stmt(stmt).map_err(|e| patch_err(e, spanned))? {
                             Signal::Return(v) => {
                                 self.env.pop_scope();
                                 return Ok(v);
@@ -2251,7 +2271,8 @@ impl Interpreter {
                             }
                             _ => {
                                 if let Stmt::Expression(expr) = stmt {
-                                    last = self.eval_expr(expr)?;
+                                    last =
+                                        self.eval_expr(expr).map_err(|e| patch_err(e, spanned))?;
                                 }
                             }
                         },

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -799,7 +799,7 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
             }
             // Recurse into body
             for inner in body {
-                collect_symbols_from_stmt(inner, line, symbols);
+                collect_symbols_from_stmt(&inner.stmt, inner.line.saturating_sub(1), symbols);
             }
         }
         Stmt::Let { name, .. } => {
@@ -860,7 +860,7 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
                 });
             }
             for s in body {
-                collect_symbols_from_stmt(s, line, symbols);
+                collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
             }
         }
         Stmt::TryCatch {
@@ -869,7 +869,7 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
             catch_body,
         } => {
             for s in try_body {
-                collect_symbols_from_stmt(s, line, symbols);
+                collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
             }
             symbols.push(DocumentSymbolInfo {
                 name: catch_var.clone(),
@@ -877,7 +877,7 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
                 line,
             });
             for s in catch_body {
-                collect_symbols_from_stmt(s, line, symbols);
+                collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
             }
         }
         Stmt::If {
@@ -886,17 +886,17 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
             ..
         } => {
             for s in then_body {
-                collect_symbols_from_stmt(s, line, symbols);
+                collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
             }
             if let Some(eb) = else_body {
                 for s in eb {
-                    collect_symbols_from_stmt(s, line, symbols);
+                    collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
                 }
             }
         }
         Stmt::ImplBlock { methods, .. } => {
             for m in methods {
-                collect_symbols_from_stmt(m, line, symbols);
+                collect_symbols_from_stmt(&m.stmt, m.line.saturating_sub(1), symbols);
             }
         }
         Stmt::While { body, .. }
@@ -908,7 +908,7 @@ fn collect_symbols_from_stmt(stmt: &Stmt, line: usize, symbols: &mut Vec<Documen
         | Stmt::ScheduleBlock { body, .. }
         | Stmt::WatchBlock { body, .. } => {
             for s in body {
-                collect_symbols_from_stmt(s, line, symbols);
+                collect_symbols_from_stmt(&s.stmt, s.line.saturating_sub(1), symbols);
             }
         }
         _ => {}
@@ -1096,7 +1096,7 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
             }
             // Search inside function body
             for inner in body {
-                if let Some(hover) = hover_from_stmt(inner, name) {
+                if let Some(hover) = hover_from_stmt(&inner.stmt, name) {
                     return Some(hover);
                 }
             }
@@ -1182,7 +1182,7 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
         }
         Stmt::ImplBlock { methods, .. } => {
             for m in methods {
-                if let Some(h) = hover_from_stmt(m, name) {
+                if let Some(h) = hover_from_stmt(&m.stmt, name) {
                     return Some(h);
                 }
             }
@@ -1195,13 +1195,13 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
             ..
         } => {
             for s in then_body {
-                if let Some(h) = hover_from_stmt(s, name) {
+                if let Some(h) = hover_from_stmt(&s.stmt, name) {
                     return Some(h);
                 }
             }
             if let Some(eb) = else_body {
                 for s in eb {
-                    if let Some(h) = hover_from_stmt(s, name) {
+                    if let Some(h) = hover_from_stmt(&s.stmt, name) {
                         return Some(h);
                     }
                 }
@@ -1218,7 +1218,7 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
         | Stmt::ScheduleBlock { body, .. }
         | Stmt::WatchBlock { body, .. } => {
             for s in body {
-                if let Some(h) = hover_from_stmt(s, name) {
+                if let Some(h) = hover_from_stmt(&s.stmt, name) {
                     return Some(h);
                 }
             }
@@ -1230,12 +1230,12 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
             ..
         } => {
             for s in try_body {
-                if let Some(h) = hover_from_stmt(s, name) {
+                if let Some(h) = hover_from_stmt(&s.stmt, name) {
                     return Some(h);
                 }
             }
             for s in catch_body {
-                if let Some(h) = hover_from_stmt(s, name) {
+                if let Some(h) = hover_from_stmt(&s.stmt, name) {
                     return Some(h);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,7 +360,7 @@ fn collect_vm_incompatible_stmt(stmt: &Stmt, issues: &mut BTreeSet<&'static str>
         Stmt::InterfaceDef { .. } => {}
         Stmt::ImplBlock { methods, .. } => {
             for method in methods {
-                collect_vm_incompatible_stmt(method, issues);
+                collect_vm_incompatible_stmt(&method.stmt, issues);
             }
         }
         Stmt::Destructure { pattern: _, value } => {
@@ -371,39 +371,39 @@ fn collect_vm_incompatible_stmt(stmt: &Stmt, issues: &mut BTreeSet<&'static str>
             catch_body,
             ..
         } => {
-            for stmt in try_body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in try_body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
-            for stmt in catch_body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in catch_body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::SafeBlock { body } => {
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::TimeoutBlock { body, .. } => {
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::RetryBlock { count, body } => {
             collect_vm_incompatible_expr(count, issues);
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::ScheduleBlock { body, .. } => {
             issues.insert("schedule blocks");
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::WatchBlock { body, .. } => {
             issues.insert("watch blocks");
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::PromptDef { .. } => {}
@@ -421,8 +421,8 @@ fn collect_vm_incompatible_stmt(stmt: &Stmt, issues: &mut BTreeSet<&'static str>
             {
                 issues.insert("decorator-driven runtime features");
             }
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::If {
@@ -430,19 +430,19 @@ fn collect_vm_incompatible_stmt(stmt: &Stmt, issues: &mut BTreeSet<&'static str>
             else_body,
             ..
         } => {
-            for stmt in then_body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in then_body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
             if let Some(else_body) = else_body {
-                for stmt in else_body {
-                    collect_vm_incompatible_stmt(stmt, issues);
+                for s in else_body {
+                    collect_vm_incompatible_stmt(&s.stmt, issues);
                 }
             }
         }
         Stmt::Match { arms, .. } => {
             for arm in arms {
-                for stmt in &arm.body {
-                    collect_vm_incompatible_stmt(stmt, issues);
+                for s in &arm.body {
+                    collect_vm_incompatible_stmt(&s.stmt, issues);
                 }
             }
         }
@@ -450,8 +450,8 @@ fn collect_vm_incompatible_stmt(stmt: &Stmt, issues: &mut BTreeSet<&'static str>
         | Stmt::While { body, .. }
         | Stmt::Loop { body }
         | Stmt::Spawn { body } => {
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Stmt::Let { value, .. } | Stmt::Expression(value) | Stmt::YieldStmt(value) => {
@@ -506,8 +506,8 @@ fn collect_vm_incompatible_expr(expr: &Expr, issues: &mut BTreeSet<&'static str>
             collect_vm_incompatible_expr(function, issues);
         }
         Expr::Lambda { body, .. } | Expr::Block(body) => {
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Expr::Object(fields) | Expr::StructInit { fields, .. } => {
@@ -578,8 +578,8 @@ fn collect_vm_incompatible_expr(expr: &Expr, issues: &mut BTreeSet<&'static str>
             // block returning null in the VM compiler, so user code that
             // depends on its parallel semantics is wrong. Reject it.
             issues.insert("spawn expressions");
-            for stmt in body {
-                collect_vm_incompatible_stmt(stmt, issues);
+            for s in body {
+                collect_vm_incompatible_stmt(&s.stmt, issues);
             }
         }
         Expr::Int(_) | Expr::Float(_) | Expr::StringLit(_) | Expr::Bool(_) | Expr::Ident(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -654,7 +654,7 @@ async fn run_source(source: &str, filename: &str, use_vm: bool, profile: bool, s
                         errors::format_error(
                             source,
                             e.line,
-                            1,
+                            if e.col > 0 { e.col } else { 1 },
                             &format!("[{}] {}", filename, e.message)
                         )
                     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,7 +642,8 @@ async fn run_source(source: &str, filename: &str, use_vm: bool, profile: bool, s
         interpreter.source = Some(source.to_string());
         let path = std::path::Path::new(filename);
         if path.exists() {
-            interpreter.source_file = Some(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
+            interpreter.source_file =
+                Some(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
         }
         interpreter.set_defer_host_runtime(true);
         match interpreter.run(&program) {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -5,6 +5,22 @@
 pub struct SpannedStmt {
     pub stmt: Stmt,
     pub line: usize,
+    pub col: usize,
+}
+
+impl SpannedStmt {
+    pub fn new(stmt: Stmt, line: usize, col: usize) -> Self {
+        Self { stmt, line, col }
+    }
+
+    /// Create a SpannedStmt with no position info (for generated/test code)
+    pub fn unspanned(stmt: Stmt) -> Self {
+        Self {
+            stmt,
+            line: 0,
+            col: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -30,7 +46,7 @@ pub enum Stmt {
         name: String,
         params: Vec<Param>,
         return_type: Option<TypeAnn>,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
         decorators: Vec<Decorator>,
         is_async: bool,
     },
@@ -45,8 +61,8 @@ pub enum Stmt {
     Return(Option<Expr>),
     If {
         condition: Expr,
-        then_body: Vec<Stmt>,
-        else_body: Option<Vec<Stmt>>,
+        then_body: Vec<SpannedStmt>,
+        else_body: Option<Vec<SpannedStmt>>,
     },
     Match {
         subject: Expr,
@@ -56,19 +72,19 @@ pub enum Stmt {
         var: String,
         var2: Option<String>,
         iterable: Expr,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     While {
         condition: Expr,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     Loop {
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     Break,
     Continue,
     Spawn {
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     DecoratorStmt(Decorator),
     TypeDef {
@@ -83,12 +99,12 @@ pub enum Stmt {
     ImplBlock {
         type_name: String,
         ability: Option<String>,
-        methods: Vec<Stmt>,
+        methods: Vec<SpannedStmt>,
     },
     TryCatch {
-        try_body: Vec<Stmt>,
+        try_body: Vec<SpannedStmt>,
         catch_var: String,
-        catch_body: Vec<Stmt>,
+        catch_body: Vec<SpannedStmt>,
     },
     Import {
         path: String,
@@ -107,28 +123,28 @@ pub enum Stmt {
     },
     /// safe { body } -- null-safe execution
     SafeBlock {
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     /// timeout N seconds { body }
     TimeoutBlock {
         duration: Expr,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     /// retry N times { body }
     RetryBlock {
         count: Expr,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     /// schedule every N seconds/minutes { body }
     ScheduleBlock {
         interval: Expr,
         unit: String,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     /// watch "path" { body }
     WatchBlock {
         path: Expr,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     /// prompt name(params) { system/user/returns }
     PromptDef {
@@ -205,10 +221,10 @@ pub enum Expr {
     },
     Lambda {
         params: Vec<Param>,
-        body: Vec<Stmt>,
+        body: Vec<SpannedStmt>,
     },
     Await(Box<Expr>),
-    Spawn(Vec<Stmt>),
+    Spawn(Vec<SpannedStmt>),
     Spread(Box<Expr>),
     Must(Box<Expr>),
     Freeze(Box<Expr>),
@@ -232,7 +248,7 @@ pub enum Expr {
         name: String,
         fields: Vec<(String, Expr)>,
     },
-    Block(Vec<Stmt>),
+    Block(Vec<SpannedStmt>),
 }
 
 #[derive(Debug, Clone)]
@@ -306,7 +322,7 @@ pub enum DecoratorArg {
 #[derive(Debug, Clone)]
 pub struct MatchArm {
     pub pattern: Pattern,
-    pub body: Vec<Stmt>,
+    pub body: Vec<SpannedStmt>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -15,16 +15,21 @@ impl Parser {
         Self { tokens, pos: 0 }
     }
 
+    /// Return (line, col) of the current token position.
+    fn current_pos(&self) -> (usize, usize) {
+        if self.pos < self.tokens.len() {
+            (self.tokens[self.pos].line, self.tokens[self.pos].col)
+        } else {
+            (0, 0)
+        }
+    }
+
     pub fn parse_program(&mut self) -> Result<Program, ParseError> {
         let mut statements = Vec::new();
         self.skip_newlines();
 
         while !self.is_at_end() {
-            let (line, col) = if self.pos < self.tokens.len() {
-                (self.tokens[self.pos].line, self.tokens[self.pos].col)
-            } else {
-                (0, 0)
-            };
+            let (line, col) = self.current_pos();
             let stmt = self.parse_statement()?;
             statements.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
@@ -277,11 +282,7 @@ impl Parser {
 
         let mut methods = Vec::new();
         while !self.check(&Token::RBrace) {
-            let (line, col) = if self.pos < self.tokens.len() {
-                (self.tokens[self.pos].line, self.tokens[self.pos].col)
-            } else {
-                (0, 0)
-            };
+            let (line, col) = self.current_pos();
             let stmt = self.parse_fn_def(Vec::new())?;
             methods.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
@@ -1826,11 +1827,7 @@ impl Parser {
         // Otherwise it's a block
         let mut stmts = Vec::new();
         while !self.check(&Token::RBrace) {
-            let (line, col) = if self.pos < self.tokens.len() {
-                (self.tokens[self.pos].line, self.tokens[self.pos].col)
-            } else {
-                (0, 0)
-            };
+            let (line, col) = self.current_pos();
             let stmt = self.parse_statement()?;
             stmts.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
@@ -1874,11 +1871,7 @@ impl Parser {
 
         let mut stmts = Vec::new();
         while !self.check(&Token::RBrace) {
-            let (line, col) = if self.pos < self.tokens.len() {
-                (self.tokens[self.pos].line, self.tokens[self.pos].col)
-            } else {
-                (0, 0)
-            };
+            let (line, col) = self.current_pos();
             let stmt = self.parse_statement()?;
             stmts.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -20,13 +20,13 @@ impl Parser {
         self.skip_newlines();
 
         while !self.is_at_end() {
-            let line = if self.pos < self.tokens.len() {
-                self.tokens[self.pos].line
+            let (line, col) = if self.pos < self.tokens.len() {
+                (self.tokens[self.pos].line, self.tokens[self.pos].col)
             } else {
-                0
+                (0, 0)
             };
             let stmt = self.parse_statement()?;
-            statements.push(SpannedStmt { stmt, line });
+            statements.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
         }
 
@@ -277,8 +277,13 @@ impl Parser {
 
         let mut methods = Vec::new();
         while !self.check(&Token::RBrace) {
+            let (line, col) = if self.pos < self.tokens.len() {
+                (self.tokens[self.pos].line, self.tokens[self.pos].col)
+            } else {
+                (0, 0)
+            };
             let stmt = self.parse_fn_def(Vec::new())?;
-            methods.push(stmt);
+            methods.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
         }
         self.expect(Token::RBrace)?;
@@ -939,8 +944,13 @@ impl Parser {
         let else_body = if self.check_else_keyword() {
             self.advance();
             if self.check(&Token::If) {
+                let (line, col) = if self.pos < self.tokens.len() {
+                    (self.tokens[self.pos].line, self.tokens[self.pos].col)
+                } else {
+                    (0, 0)
+                };
                 let elif = self.parse_if()?;
-                Some(vec![elif])
+                Some(vec![SpannedStmt::new(elif, line, col)])
             } else {
                 Some(self.parse_block()?)
             }
@@ -970,8 +980,13 @@ impl Parser {
             let body = if self.check(&Token::LBrace) {
                 self.parse_block()?
             } else {
+                let (line, col) = if self.pos < self.tokens.len() {
+                    (self.tokens[self.pos].line, self.tokens[self.pos].col)
+                } else {
+                    (0, 0)
+                };
                 let stmt = self.parse_statement()?;
-                vec![stmt]
+                vec![SpannedStmt::new(stmt, line, col)]
             };
 
             arms.push(MatchArm { pattern, body });
@@ -1302,7 +1317,7 @@ impl Parser {
                 type_ann: None,
                 default: None,
             }],
-            body: vec![Stmt::Return(Some(predicate))],
+            body: vec![SpannedStmt::unspanned(Stmt::Return(Some(predicate)))],
         })
     }
 
@@ -1670,11 +1685,11 @@ impl Parser {
                     None
                 };
                 // Wrap as block expression
-                Ok(Expr::Block(vec![Stmt::If {
+                Ok(Expr::Block(vec![SpannedStmt::unspanned(Stmt::If {
                     condition: cond,
                     then_body,
                     else_body,
-                }]))
+                })]))
             }
 
             Token::Type => {
@@ -1693,12 +1708,12 @@ impl Parser {
 
             Token::When => {
                 let when_stmt = self.parse_when()?;
-                Ok(Expr::Block(vec![when_stmt]))
+                Ok(Expr::Block(vec![SpannedStmt::unspanned(when_stmt)]))
             }
 
             Token::Safe => {
                 let safe_stmt = self.parse_safe_block()?;
-                Ok(Expr::Block(vec![safe_stmt]))
+                Ok(Expr::Block(vec![SpannedStmt::unspanned(safe_stmt)]))
             }
 
             _ => Err(self.error(&format!("unexpected token: {:?}", self.current_token()))),
@@ -1811,7 +1826,13 @@ impl Parser {
         // Otherwise it's a block
         let mut stmts = Vec::new();
         while !self.check(&Token::RBrace) {
-            stmts.push(self.parse_statement()?);
+            let (line, col) = if self.pos < self.tokens.len() {
+                (self.tokens[self.pos].line, self.tokens[self.pos].col)
+            } else {
+                (0, 0)
+            };
+            let stmt = self.parse_statement()?;
+            stmts.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
         }
         self.expect(Token::RBrace)?;
@@ -1846,14 +1867,20 @@ impl Parser {
 
     // ========== Helpers ==========
 
-    fn parse_block(&mut self) -> Result<Vec<Stmt>, ParseError> {
+    fn parse_block(&mut self) -> Result<Vec<SpannedStmt>, ParseError> {
         self.skip_newlines();
         self.expect(Token::LBrace)?;
         self.skip_newlines();
 
         let mut stmts = Vec::new();
         while !self.check(&Token::RBrace) {
-            stmts.push(self.parse_statement()?);
+            let (line, col) = if self.pos < self.tokens.len() {
+                (self.tokens[self.pos].line, self.tokens[self.pos].col)
+            } else {
+                (0, 0)
+            };
+            let stmt = self.parse_statement()?;
+            stmts.push(SpannedStmt::new(stmt, line, col));
             self.skip_newlines();
         }
 

--- a/src/runtime/metadata.rs
+++ b/src/runtime/metadata.rs
@@ -31,7 +31,7 @@ pub struct ServerPlan {
 pub struct SchedulePlan {
     pub interval: Expr,
     pub unit: String,
-    pub body: Vec<Stmt>,
+    pub body: Vec<SpannedStmt>,
     pub line: usize,
 }
 
@@ -39,7 +39,7 @@ pub struct SchedulePlan {
 #[derive(Clone, Debug)]
 pub struct WatchPlan {
     pub path: Expr,
-    pub body: Vec<Stmt>,
+    pub body: Vec<SpannedStmt>,
     pub line: usize,
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -219,10 +219,6 @@ impl TypeChecker {
         for spanned in &program.statements {
             self.collect_definitions(&spanned.stmt);
         }
-        // Note: current_line only updates for top-level SpannedStmt. Warnings inside
-        // function bodies inherit the parent function's line because body: Vec<Stmt>
-        // has no span info. This is an AST limitation — fixing it requires making
-        // inner statements Spanned (tracked as roadmap item 1.5).
         for spanned in &program.statements {
             self.current_line = spanned.line;
             self.check_stmt(&spanned.stmt);
@@ -278,13 +274,13 @@ impl TypeChecker {
             Stmt::ImplBlock {
                 type_name, methods, ..
             } => {
-                for method in methods {
+                for spanned_method in methods {
                     if let Stmt::FnDef {
                         name: method_name,
                         params,
                         return_type,
                         ..
-                    } = method
+                    } = &spanned_method.stmt
                     {
                         let qualified = format!("{}::{}", type_name, method_name);
                         let param_info: Vec<(String, Option<InferredType>)> = params
@@ -395,12 +391,13 @@ impl TypeChecker {
                 }
 
                 for s in body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
 
                 // Collect definitions for nested functions
                 for s in body {
-                    self.collect_definitions(s);
+                    self.collect_definitions(&s.stmt);
                 }
 
                 self.current_fn_return = prev_return;
@@ -427,29 +424,34 @@ impl TypeChecker {
                     // Not an error in a dynamic language, just informational
                 }
                 for s in then_body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
                 if let Some(else_b) = else_body {
                     for s in else_b {
-                        self.check_stmt(s);
+                        self.current_line = s.line;
+                        self.check_stmt(&s.stmt);
                     }
                 }
             }
             Stmt::For { iterable, body, .. } => {
                 self.infer_expr(iterable);
                 for s in body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
             }
             Stmt::While { condition, body } => {
                 self.infer_expr(condition);
                 for s in body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
             }
             Stmt::Loop { body } | Stmt::Spawn { body } => {
                 for s in body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
             }
             Stmt::Return(None) => {}
@@ -460,7 +462,8 @@ impl TypeChecker {
                 self.infer_expr(subject);
                 for arm in arms {
                     for s in &arm.body {
-                        self.check_stmt(s);
+                        self.current_line = s.line;
+                        self.check_stmt(&s.stmt);
                     }
                 }
             }
@@ -672,7 +675,8 @@ impl TypeChecker {
                     }
                 }
                 for s in body {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
                 InferredType::Function(vec![], Box::new(InferredType::Unknown))
             }
@@ -699,7 +703,8 @@ impl TypeChecker {
 
             Expr::Block(stmts) => {
                 for s in stmts {
-                    self.check_stmt(s);
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
                 InferredType::Unknown
             }
@@ -709,8 +714,9 @@ impl TypeChecker {
             }
 
             Expr::Spawn(body) => {
-                for stmt in body {
-                    self.check_stmt(stmt);
+                for s in body {
+                    self.current_line = s.line;
+                    self.check_stmt(&s.stmt);
                 }
                 InferredType::Unknown // TaskHandle type
             }

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -635,7 +635,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                 fc.add_local(&param.name, true);
             }
             for s in body {
-                compile_stmt(&mut fc, s)?;
+                fc.current_line = s.line;
+                compile_stmt(&mut fc, &s.stmt)?;
             }
             fc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
             fc.chunk.max_registers = fc.max_register;
@@ -684,7 +685,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in then_body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
 
@@ -693,7 +695,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                 c.patch_jump(else_jump);
                 c.begin_scope();
                 for s in eb {
-                    compile_stmt(c, s)?;
+                    c.current_line = s.line;
+                    compile_stmt(c, &s.stmt)?;
                 }
                 c.end_scope();
                 c.patch_jump(end_jump);
@@ -718,7 +721,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
 
@@ -744,7 +748,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
 
@@ -792,7 +797,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             c.emit(encode_abc(OpCode::GetIndex, var_reg, arr_reg, idx_reg), 0);
 
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
 
@@ -845,7 +851,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                     Pattern::Wildcard => {
                         c.begin_scope();
                         for s in &arm.body {
-                            compile_stmt(c, s)?;
+                            c.current_line = s.line;
+                            compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
                         break;
@@ -872,7 +879,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                         let vr = c.add_local(name, false);
                         c.emit(encode_abc(OpCode::Move, vr, subj, 0), 0);
                         for s in &arm.body {
-                            compile_stmt(c, s)?;
+                            c.current_line = s.line;
+                            compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
 
@@ -890,7 +898,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
                         c.begin_scope();
                         for s in &arm.body {
-                            compile_stmt(c, s)?;
+                            c.current_line = s.line;
+                            compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
 
@@ -918,7 +927,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                             }
                         }
                         for s in &arm.body {
-                            compile_stmt(c, s)?;
+                            c.current_line = s.line;
+                            compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
 
@@ -970,10 +980,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                     .collect::<Vec<_>>();
                 let constructor = Expr::Lambda {
                     params,
-                    body: vec![Stmt::Return(Some(variant_object_expr(
-                        name,
-                        &variant.name,
-                        &param_names,
+                    body: vec![SpannedStmt::unspanned(Stmt::Return(Some(
+                        variant_object_expr(name, &variant.name, &param_names),
                     )))],
                 };
                 compile_set_global_expr(c, &variant.name, constructor)?;
@@ -1160,7 +1168,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
             c.cleanup_contexts.pop();
@@ -1191,7 +1200,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
 
@@ -1244,7 +1254,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
             c.cleanup_contexts.pop();
@@ -1304,10 +1315,10 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             ability,
             methods,
         } => {
-            for method_stmt in methods {
+            for method_spanned in methods {
                 let Stmt::FnDef {
                     name, params, body, ..
-                } = method_stmt
+                } = &method_spanned.stmt
                 else {
                     return Err(CompileError::new(
                         "impl/give blocks may only contain methods",
@@ -1357,7 +1368,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in try_body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
             c.cleanup_contexts.pop();
@@ -1373,7 +1385,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                 mutable: false,
             });
             for s in catch_body {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
             c.patch_jump(end_jump);
@@ -1435,7 +1448,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             sc.current_line = c.current_line;
             sc.begin_scope();
             for s in body {
-                compile_stmt(&mut sc, s)?;
+                sc.current_line = s.line;
+                compile_stmt(&mut sc, &s.stmt)?;
             }
             sc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
             sc.chunk.max_registers = sc.max_register;
@@ -1626,7 +1640,8 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
                 lc.add_local(&p.name, true);
             }
             for s in body {
-                compile_stmt(&mut lc, s)?;
+                lc.current_line = s.line;
+                compile_stmt(&mut lc, &s.stmt)?;
             }
             lc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
             lc.chunk.max_registers = lc.max_register;
@@ -1653,7 +1668,8 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
         Expr::Block(stmts) => {
             c.begin_scope();
             for s in stmts {
-                compile_stmt(c, s)?;
+                c.current_line = s.line;
+                compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
         }
@@ -1663,7 +1679,8 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
         Expr::Spawn(body) => {
             // VM spawn: compile as synchronous call for now (VM concurrency is M4.3)
             for stmt in body {
-                compile_stmt(c, stmt)?;
+                c.current_line = stmt.line;
+                compile_stmt(c, &stmt.stmt)?;
             }
             c.emit(encode_abc(OpCode::LoadNull, dst, 0, 0), 0);
         }


### PR DESCRIPTION
## Summary

- **AST span threading** — all inner statement bodies (if, for, while, fn, match, try/catch, spawn, etc.) changed from Vec<Stmt> to Vec<SpannedStmt> with per-statement line and column info
- **Line-accurate runtime errors** — errors inside nested blocks now report the exact inner line, not the enclosing top-level statement. Uses ariadne for Rust-style source snippets with carets.
- **Type checker line tracking** — inner body statements now update current_line, giving more accurate warning positions
- **VM compiler line tracking** — inner body compilation updates current_line for better bytecode line tables

## Before vs After

Before: an undefined variable inside a nested if/for/fn would show the top-level statement line.
After: it shows the exact inner line with the source snippet.

## Scope

8 files changed across parser, interpreter, VM compiler, type checker, LSP, and runtime metadata. All changes are mechanical — the AST type change cascaded to every consumer. SpannedStmt::unspanned() helper used for generated/synthetic code.

## Test plan

- [x] 828 cargo tests pass
- [x] examples/hello.fg and examples/functional.fg run correctly
- [x] Verified nested error reporting: errors inside if/for/fn bodies show correct inner line
- [x] VM mode still works (--vm flag)