### PR TITLE
feat: JIT expansion — logical ops, 8-arg dispatch, tests

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -172,10 +172,13 @@ Plus GenZ debug kit (sus, bruh, bet, no_cap, ick) and execution helpers (cook, y
 
 - **What:** These are runtime features (cron + file watcher). Currently rejected by the compiler. Implementing them requires the async runtime from 3.1.
 
-### 3.6 JIT expansion
+### ~~3.6 JIT expansion~~ ✅ DONE (PR #13)
 
-- **What:** Extend JIT beyond integer loops. Float arithmetic, string operations, function calls. This is Cranelift IR work in `src/vm/jit/ir_builder.rs`.
-- **Note:** Only valuable after VM parity is solid. JIT is a performance optimization on top of a working VM.
+Fixed And/Or from bitwise to logical semantics (result is 0/1, not the raw operand value).
+Extended JIT dispatch from max 3 arguments to 8 for both integer and float functions.
+24 new tests covering logical operators, multi-arg functions, float operations, recursive
+algorithms (fib(30), GCD, Collatz), and comparison operators. String operations and
+inter-function calls deferred — requires NaN-boxing runtime (Milestone 2).
 
 ### Order of attack
 
@@ -198,4 +201,4 @@ Each phase is independent. When picking up work:
 5. After each item: `cargo test`, atomic commit, update CHANGELOG
 6. After each phase: cut a release
 
-Current status: **Phase 3 — items 3.2-3.4 complete. Remaining: 3.1 (async VM), 3.5 (schedule/watch), 3.6 (JIT expansion). Phase 2 item 2.4 (publish) deferred.**
+Current status: **Phase 3 — items 3.2-3.4, 3.6 complete. Remaining: 3.1 (async VM), 3.5 (schedule/watch). Phase 2 item 2.4 (publish) deferred.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Source spans in AST** — all inner statement bodies (`if`, `for`, `while`, `fn`, `match`, `try/catch`, etc.) now carry per-statement line and column info via `SpannedStmt`. Runtime errors report the exact source line, even inside deeply nested blocks.
 - **VM stdlib parity: 47 new builtins** — added 4 missing module namespaces (`npc`, `url`, `toml`, `ws`) and 43 standalone builtins to the VM: collections (`first`, `last`, `zip`, `flatten`, `chunk`, `slice`, `compact`, `partition`, `group_by`, `sort_by`, `for_each`, `take_n`, `skip`, `frequencies`, `sample`, `shuffle`), strings (`typeof`, `substring`, `index_of`, `last_index_of`, `capitalize`, `title`, `upper`, `lower`, `trim`, `pad_start`, `pad_end`, `repeat_str`, `count`, `slugify`, `snake_case`, `camel_case`), GenZ debug kit, and execution helpers
 - **Line-accurate runtime errors** — errors inside nested blocks now show the correct inner line with source snippets via ariadne, instead of pointing at the top-level statement
+- **JIT: logical And/Or** — `&&`/`||` in JIT-compiled functions now use logical semantics (result is 0 or 1) instead of bitwise AND/OR which produced wrong results for non-boolean integers (e.g. `2 && 3` was `2`, now correctly `1`)
+- **JIT: support up to 8 function arguments** — JIT dispatch previously silently dropped arguments beyond 3; now supports 0–8 arguments for both integer and float functions
+- **JIT: 24 new tests** — comprehensive coverage for logical operators, multi-argument functions, float arithmetic, recursive algorithms, and comparison operators
 
 ---
 

--- a/src/vm/jit/ir_builder.rs
+++ b/src/vm/jit/ir_builder.rs
@@ -272,7 +272,12 @@ pub fn build_function<M: Module>(
                         let extended = b.ins().uextend(I64, both);
                         b.ins().fcvt_from_uint(F64, extended)
                     } else {
-                        b.ins().band(l, r)
+                        // Logical AND: both operands must be non-zero → result is 1 or 0
+                        let zero = b.ins().iconst(I64, 0);
+                        let l_truthy = b.ins().icmp(IntCC::NotEqual, l, zero);
+                        let r_truthy = b.ins().icmp(IntCC::NotEqual, r, zero);
+                        let both = b.ins().band(l_truthy, r_truthy);
+                        b.ins().uextend(I64, both)
                     };
                     b.def_var(regs[a], result);
                     b.ins().jump(next, &[]);
@@ -288,7 +293,12 @@ pub fn build_function<M: Module>(
                         let extended = b.ins().uextend(I64, either);
                         b.ins().fcvt_from_uint(F64, extended)
                     } else {
-                        b.ins().bor(l, r)
+                        // Logical OR: either operand non-zero → result is 1 or 0
+                        let zero = b.ins().iconst(I64, 0);
+                        let l_truthy = b.ins().icmp(IntCC::NotEqual, l, zero);
+                        let r_truthy = b.ins().icmp(IntCC::NotEqual, r, zero);
+                        let either = b.ins().bor(l_truthy, r_truthy);
+                        b.ins().uextend(I64, either)
                     };
                     b.def_var(regs[a], result);
                     b.ins().jump(next, &[]);

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1553,7 +1553,7 @@ impl VM {
                             && self.profiler.is_hot(&func_name)
                         {
                             let type_info = super::jit::type_analysis::analyze(&chunk);
-                            if !type_info.has_unsupported_ops {
+                            if !type_info.has_unsupported_ops && chunk.arity <= 8 {
                                 if let Ok(mut jit) = super::jit::jit_module::JitCompiler::new() {
                                     if let Ok(ptr) = jit.compile_function(&chunk, &func_name) {
                                         self.jit_cache.insert(

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -14,6 +14,111 @@ pub struct JitEntry {
     pub uses_float: bool,
 }
 
+/// Call a JIT-compiled function with arbitrary i64 arguments.
+/// Supports 0–8 args; panics beyond that (Forge functions rarely exceed 8).
+unsafe fn jit_call_i64(ptr: *const u8, args: &[i64]) -> i64 {
+    match args.len() {
+        0 => {
+            let f: extern "C" fn() -> i64 = std::mem::transmute(ptr);
+            f()
+        }
+        1 => {
+            let f: extern "C" fn(i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0])
+        }
+        2 => {
+            let f: extern "C" fn(i64, i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0], args[1])
+        }
+        3 => {
+            let f: extern "C" fn(i64, i64, i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2])
+        }
+        4 => {
+            let f: extern "C" fn(i64, i64, i64, i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3])
+        }
+        5 => {
+            let f: extern "C" fn(i64, i64, i64, i64, i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3], args[4])
+        }
+        6 => {
+            let f: extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3], args[4], args[5])
+        }
+        7 => {
+            let f: extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64 =
+                std::mem::transmute(ptr);
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6],
+            )
+        }
+        8 => {
+            let f: extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 =
+                std::mem::transmute(ptr);
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
+            )
+        }
+        _ => panic!(
+            "JIT dispatch supports up to 8 arguments, got {}",
+            args.len()
+        ),
+    }
+}
+
+/// Call a JIT-compiled function with arbitrary f64 arguments.
+unsafe fn jit_call_f64(ptr: *const u8, args: &[f64]) -> f64 {
+    match args.len() {
+        0 => {
+            let f: extern "C" fn() -> f64 = std::mem::transmute(ptr);
+            f()
+        }
+        1 => {
+            let f: extern "C" fn(f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0])
+        }
+        2 => {
+            let f: extern "C" fn(f64, f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0], args[1])
+        }
+        3 => {
+            let f: extern "C" fn(f64, f64, f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2])
+        }
+        4 => {
+            let f: extern "C" fn(f64, f64, f64, f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3])
+        }
+        5 => {
+            let f: extern "C" fn(f64, f64, f64, f64, f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3], args[4])
+        }
+        6 => {
+            let f: extern "C" fn(f64, f64, f64, f64, f64, f64) -> f64 = std::mem::transmute(ptr);
+            f(args[0], args[1], args[2], args[3], args[4], args[5])
+        }
+        7 => {
+            let f: extern "C" fn(f64, f64, f64, f64, f64, f64, f64) -> f64 =
+                std::mem::transmute(ptr);
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6],
+            )
+        }
+        8 => {
+            let f: extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
+                std::mem::transmute(ptr);
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
+            )
+        }
+        _ => panic!(
+            "JIT dispatch supports up to 8 arguments, got {}",
+            args.len()
+        ),
+    }
+}
+
 pub struct VM {
     pub registers: Vec<Value>,
     pub frames: Vec<CallFrame>,
@@ -1483,34 +1588,7 @@ impl VM {
                                             _ => 0.0,
                                         })
                                         .collect();
-                                    let result: f64 = unsafe {
-                                        match raw_args.len() {
-                                            0 => {
-                                                let f: extern "C" fn() -> f64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f()
-                                            }
-                                            1 => {
-                                                let f: extern "C" fn(f64) -> f64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(raw_args[0])
-                                            }
-                                            2 => {
-                                                let f: extern "C" fn(f64, f64) -> f64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(raw_args[0], raw_args[1])
-                                            }
-                                            _ => {
-                                                let f: extern "C" fn(f64, f64, f64) -> f64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(
-                                                    raw_args[0],
-                                                    raw_args[1],
-                                                    raw_args.get(2).copied().unwrap_or(0.0),
-                                                )
-                                            }
-                                        }
-                                    };
+                                    let result: f64 = unsafe { jit_call_f64(entry.ptr, &raw_args) };
                                     if result.fract() == 0.0
                                         && result >= i64::MIN as f64
                                         && result <= i64::MAX as f64
@@ -1534,34 +1612,7 @@ impl VM {
                                             _ => 0,
                                         })
                                         .collect();
-                                    let result: i64 = unsafe {
-                                        match raw_args.len() {
-                                            0 => {
-                                                let f: extern "C" fn() -> i64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f()
-                                            }
-                                            1 => {
-                                                let f: extern "C" fn(i64) -> i64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(raw_args[0])
-                                            }
-                                            2 => {
-                                                let f: extern "C" fn(i64, i64) -> i64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(raw_args[0], raw_args[1])
-                                            }
-                                            _ => {
-                                                let f: extern "C" fn(i64, i64, i64) -> i64 =
-                                                    std::mem::transmute(entry.ptr);
-                                                f(
-                                                    raw_args[0],
-                                                    raw_args[1],
-                                                    raw_args.get(2).copied().unwrap_or(0),
-                                                )
-                                            }
-                                        }
-                                    };
+                                    let result: i64 = unsafe { jit_call_i64(entry.ptr, &raw_args) };
                                     Value::Int(result)
                                 };
                                 self.profiler.exit_function();

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1367,6 +1367,210 @@ mod jit_tests {
         assert!(result.is_err());
     }
 
+    // ----- And/Or logical semantics -----
+
+    #[test]
+    fn jit_logical_and() {
+        // 2 && 3 should produce 1 (true), not 2 (bitwise)
+        let out = run_jit_function("fn test(a, b) { return a && b }\nprintln(test(2, 3))");
+        assert_eq!(out, vec!["1"]);
+    }
+
+    #[test]
+    fn jit_logical_and_falsy() {
+        let out = run_jit_function("fn test(a, b) { return a && b }\nprintln(test(0, 3))");
+        assert_eq!(out, vec!["0"]);
+    }
+
+    #[test]
+    fn jit_logical_or() {
+        // 2 || 0 should produce 1 (true), not 2 (bitwise)
+        let out = run_jit_function("fn test(a, b) { return a || b }\nprintln(test(2, 0))");
+        assert_eq!(out, vec!["1"]);
+    }
+
+    #[test]
+    fn jit_logical_or_both_false() {
+        let out = run_jit_function("fn test(a, b) { return a || b }\nprintln(test(0, 0))");
+        assert_eq!(out, vec!["0"]);
+    }
+
+    #[test]
+    fn jit_logical_not() {
+        let out = run_jit_function("fn test(x) { return !x }\nprintln(test(0))\nprintln(test(42))");
+        assert_eq!(out, vec!["1", "0"]);
+    }
+
+    // ----- Multi-argument functions (4+) -----
+
+    #[test]
+    fn jit_four_args() {
+        let out = run_jit_function(
+            "fn sum4(a, b, c, d) { return a + b + c + d }\nprintln(sum4(1, 2, 3, 4))",
+        );
+        assert_eq!(out, vec!["10"]);
+    }
+
+    #[test]
+    fn jit_five_args() {
+        let out = run_jit_function(
+            "fn sum5(a, b, c, d, e) { return a + b + c + d + e }\nprintln(sum5(1, 2, 3, 4, 5))",
+        );
+        assert_eq!(out, vec!["15"]);
+    }
+
+    #[test]
+    fn jit_six_args() {
+        let out = run_jit_function(
+            "fn sum6(a, b, c, d, e, f) { return a + b + c + d + e + f }\nprintln(sum6(1, 2, 3, 4, 5, 6))",
+        );
+        assert_eq!(out, vec!["21"]);
+    }
+
+    #[test]
+    fn jit_four_args_float() {
+        let out = run_jit_function(
+            "fn sum4f(a, b, c, d) { return a + b + c + d + 0.5 }\nprintln(sum4f(1, 2, 3, 4))",
+        );
+        assert_eq!(out, vec!["10.5"]);
+    }
+
+    // ----- Float operations -----
+
+    #[test]
+    fn jit_float_division() {
+        // Use 0.0 to force float mode in type analysis
+        let out =
+            run_jit_function("fn fdiv(a, b) { return (a + 0.0) / b }\nprintln(fdiv(7.0, 2.0))");
+        assert_eq!(out, vec!["3.5"]);
+    }
+
+    #[test]
+    fn jit_float_modulo() {
+        let out =
+            run_jit_function("fn fmod(a, b) { return (a + 0.0) % b }\nprintln(fmod(7.5, 2.0))");
+        assert_eq!(out, vec!["1.5"]);
+    }
+
+    #[test]
+    fn jit_float_comparison() {
+        let out = run_jit_function(
+            "fn fmax(a, b) { if a > b + 0.0 { return a } return b }\nprintln(fmax(1.5, 2.5))\nprintln(fmax(3.5, 0.5))",
+        );
+        assert_eq!(out, vec!["2.5", "3.5"]);
+    }
+
+    #[test]
+    fn jit_float_equality() {
+        let out = run_jit_function(
+            "fn feq(a, b) { return a + 0.0 == b }\nprintln(feq(1.5, 1.5))\nprintln(feq(1.5, 2.5))",
+        );
+        assert_eq!(out, vec!["1", "0"]);
+    }
+
+    #[test]
+    fn jit_float_and_or() {
+        // Use 0.0 constant to force float mode
+        let out = run_jit_function(
+            "fn fand(a, b) { return (a + 0.0) && (b + 0.0) }\nfn foor(a, b) { return (a + 0.0) || (b + 0.0) }\nprintln(fand(1.5, 2.5))\nprintln(fand(0.0, 2.5))\nprintln(foor(0.0, 0.0))\nprintln(foor(0.0, 1.5))",
+        );
+        assert_eq!(out, vec!["1", "0", "0", "1"]);
+    }
+
+    #[test]
+    fn jit_mixed_int_float_args() {
+        // When function has float constants, all args are promoted to f64
+        let out = run_jit_function("fn scale(x) { return x * 2.5 }\nprintln(scale(4))");
+        assert_eq!(out, vec!["10"]);
+    }
+
+    // ----- Recursive + complex -----
+
+    #[test]
+    fn jit_fib_30() {
+        let out = run_jit_function(
+            "fn fib(n) { if n <= 1 { return n } return fib(n - 1) + fib(n - 2) }\nprintln(fib(30))",
+        );
+        assert_eq!(out, vec!["832040"]);
+    }
+
+    #[test]
+    fn jit_gcd() {
+        let out = run_jit_function(
+            "fn gcd(a, b) { if b == 0 { return a } return gcd(b, a % b) }\nprintln(gcd(48, 18))",
+        );
+        assert_eq!(out, vec!["6"]);
+    }
+
+    #[test]
+    fn jit_power() {
+        let out = run_jit_function(
+            "fn pow_rec(base, exp) { if exp == 0 { return 1 } return base * pow_rec(base, exp - 1) }\nprintln(pow_rec(2, 10))",
+        );
+        assert_eq!(out, vec!["1024"]);
+    }
+
+    #[test]
+    fn jit_collatz_steps() {
+        let out = run_jit_function(
+            "fn collatz(n) { if n == 1 { return 0 } if n % 2 == 0 { return 1 + collatz(n / 2) } return 1 + collatz(3 * n + 1) }\nprintln(collatz(27))",
+        );
+        assert_eq!(out, vec!["111"]);
+    }
+
+    #[test]
+    fn jit_nested_conditionals() {
+        let out = run_jit_function(
+            "fn classify(n) { if n < 0 { return -1 } if n == 0 { return 0 } return 1 }\nprintln(classify(-5))\nprintln(classify(0))\nprintln(classify(42))",
+        );
+        assert_eq!(out, vec!["-1", "0", "1"]);
+    }
+
+    #[test]
+    fn jit_while_loop_countdown() {
+        let out = run_jit_function(
+            "fn countdown(n) { let mut total = 0\nwhile n > 0 { total = total + n\nn = n - 1 }\nreturn total }\nprintln(countdown(10))",
+        );
+        assert_eq!(out, vec!["55"]);
+    }
+
+    #[test]
+    fn jit_boolean_chain() {
+        // Test chaining logical operators
+        let out = run_jit_function(
+            "fn test(a, b, c) { return a && b && c }\nprintln(test(1, 1, 1))\nprintln(test(1, 0, 1))",
+        );
+        assert_eq!(out, vec!["1", "0"]);
+    }
+
+    #[test]
+    fn jit_all_comparisons() {
+        let out = run_jit_function(
+            "fn cmp(a, b) { \
+            if a == b { return 1 } \
+            if a != b { return 2 } \
+            return 0 }\n\
+            println(cmp(5, 5))\n\
+            println(cmp(5, 3))",
+        );
+        assert_eq!(out, vec!["1", "2"]);
+    }
+
+    #[test]
+    fn jit_lte_gte() {
+        let out = run_jit_function(
+            "fn test_lte(a, b) { return a <= b }\n\
+            fn test_gte(a, b) { return a >= b }\n\
+            println(test_lte(3, 5))\n\
+            println(test_lte(5, 5))\n\
+            println(test_lte(7, 5))\n\
+            println(test_gte(3, 5))\n\
+            println(test_gte(5, 5))\n\
+            println(test_gte(7, 5))",
+        );
+        assert_eq!(out, vec!["1", "1", "0", "0", "1", "1"]);
+    }
+
     // ----- VMError stack trace tests -----
     //
     // Before this work the compiler emitted every instruction with line=0,


### PR DESCRIPTION
## Summary

- **And/Or fix**: Changed from bitwise `band`/`bor` to logical semantics in Cranelift IR — `2 && 3` now correctly returns `1` instead of `2`
- **8-arg dispatch**: JIT-compiled functions now support 0–8 arguments (was capped at 3, silently dropping extra args). Extracted `jit_call_i64`/`jit_call_f64` helpers
- **24 new tests**: Logical operators, multi-argument functions (4–6 args), float division/modulo/comparison/equality, float And/Or, recursive algorithms (fib(30), GCD, power, Collatz), nested conditionals, while loops, comparison chains, lte/gte

## Test plan

- [x] All 885 tests pass (`cargo test`)
- [x] 44 JIT-specific tests pass (was 20, now 44)
- [x] Logical And/Or verified: `2 && 3 = 1`, `0 && 3 = 0`, `2 || 0 = 1`
- [x] 4–6 arg functions verified: `sum4(1,2,3,4) = 10`, `sum6(1..6) = 21`
- [x] Float operations verified in float-mode (with constant to trigger type analysis)
- [x] Recursive JIT: fib(30) = 832040, gcd(48,18) = 6, collatz(27) = 111

🤖 Generated with [Claude Code](https://claude.com/claude-code)