### PR TITLE
feat: forge test --coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`forge test --coverage`** — line coverage reporting for Forge test files. Tracks executed lines during test runs and displays per-file and overall coverage percentages with color-coded output (green ≥80%, yellow ≥50%, red <50%).
+
 - **`forge publish`** — package and publish Forge projects to the local filesystem registry (`~/.forge/registry/<name>/<version>/`). Supports `--dry-run` to preview without publishing and `--registry` to specify a custom registry path. Validates manifest fields, computes SHA-256 checksums, and excludes non-source files (forge_modules, .git, tests, etc.).
 - **VM as default engine** — the bytecode VM is now the default execution engine for `forge run`. The interpreter is available via `--interp` flag. Programs using decorator-driven HTTP servers (`@server`, `@get`, etc.) automatically fall back to the interpreter.
 - **VM `must` expression** — `must Ok(42)` unwraps to `42`, `must Err("x")` crashes with clear error, `must null` crashes. Full parity with interpreter semantics.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -366,6 +366,8 @@ pub struct Interpreter {
     pub source: Option<String>,
     /// Path of the currently executing source file (for relative imports)
     pub source_file: Option<std::path::PathBuf>,
+    /// Coverage tracking: set of executed line numbers (when enabled)
+    pub coverage: Option<std::collections::HashSet<usize>>,
 }
 
 impl Interpreter {
@@ -382,6 +384,7 @@ impl Interpreter {
             current_line: 0,
             source: None,
             source_file: None,
+            coverage: None,
         };
         interp.register_builtins();
         interp
@@ -1551,6 +1554,11 @@ impl Interpreter {
         let mut last_expr_value = Value::Null;
         for s in stmts {
             self.current_line = s.line;
+            if let Some(ref mut cov) = self.coverage {
+                if s.line > 0 {
+                    cov.insert(s.line);
+                }
+            }
             let stmt = &s.stmt;
             if let Stmt::Expression(expr) = stmt {
                 last_expr_value = self.eval_expr(expr).map_err(|mut e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,9 @@ enum Command {
         /// Filter tests by name pattern
         #[arg(long)]
         filter: Option<String>,
+        /// Show line coverage report after tests
+        #[arg(long)]
+        coverage: bool,
     },
     /// Create a new Forge project
     New {
@@ -250,7 +253,11 @@ async fn main() {
         Some(Command::Fmt { files, check }) => {
             formatter::format_files(&files, check);
         }
-        Some(Command::Test { dir, filter }) => {
+        Some(Command::Test {
+            dir,
+            filter,
+            coverage,
+        }) => {
             let test_dir = if dir == "tests" {
                 if let Some(m) = manifest::load_manifest() {
                     m.test.directory
@@ -260,7 +267,7 @@ async fn main() {
             } else {
                 dir
             };
-            testing::run_tests(&test_dir, filter.as_deref());
+            testing::run_tests(&test_dir, filter.as_deref(), coverage);
         }
         Some(Command::New { name }) => {
             scaffold::create_project(&name);

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 #[cfg(test)]
 pub mod parity;
 
-pub fn run_tests(test_dir: &str, filter: Option<&str>) {
+pub fn run_tests(test_dir: &str, filter: Option<&str>, coverage: bool) {
     let dir = Path::new(test_dir);
     if !dir.exists() {
         eprintln!(
@@ -26,6 +26,7 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>) {
     let mut passed = 0;
     let mut failed = 0;
     let mut skipped = 0;
+    let mut coverage_data: Vec<(String, usize, usize)> = Vec::new();
 
     println!();
 
@@ -112,6 +113,9 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>) {
 
         // Run the full program first to define all functions
         let mut interpreter = Interpreter::new();
+        if coverage {
+            interpreter.coverage = Some(std::collections::HashSet::new());
+        }
         if let Err(e) = interpreter.run(&program) {
             eprintln!("    \x1B[31mERROR\x1B[0m  setup — {}", e.message);
             failed += 1;
@@ -185,6 +189,25 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>) {
                 }
             }
         }
+        if coverage {
+            if let Some(ref cov) = interpreter.coverage {
+                let executable_lines = source
+                    .lines()
+                    .enumerate()
+                    .filter(|(_, line)| {
+                        let trimmed = line.trim();
+                        !trimmed.is_empty()
+                            && !trimmed.starts_with("//")
+                            && !trimmed.starts_with("/*")
+                            && trimmed != "}"
+                            && trimmed != "{"
+                    })
+                    .count();
+                let executed = cov.len();
+                coverage_data.push((path_str.clone(), executable_lines, executed));
+            }
+        }
+
         println!();
     }
 
@@ -198,6 +221,51 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>) {
         passed, failed, skip_msg, total
     );
     println!();
+
+    if coverage && !coverage_data.is_empty() {
+        println!("  \x1B[1mCoverage\x1B[0m");
+        println!();
+        let mut total_executable = 0usize;
+        let mut total_executed = 0usize;
+        for (file, executable, executed) in &coverage_data {
+            total_executable += executable;
+            total_executed += executed;
+            let pct = if *executable > 0 {
+                (*executed as f64 / *executable as f64 * 100.0).min(100.0)
+            } else {
+                100.0
+            };
+            let color = if pct >= 80.0 {
+                "\x1B[32m"
+            } else if pct >= 50.0 {
+                "\x1B[33m"
+            } else {
+                "\x1B[31m"
+            };
+            println!(
+                "    {}{:5.1}%\x1B[0m  {} ({}/{})",
+                color, pct, file, executed, executable
+            );
+        }
+        let overall = if total_executable > 0 {
+            (total_executed as f64 / total_executable as f64 * 100.0).min(100.0)
+        } else {
+            100.0
+        };
+        println!();
+        let overall_color = if overall >= 80.0 {
+            "\x1B[32m"
+        } else if overall >= 50.0 {
+            "\x1B[33m"
+        } else {
+            "\x1B[31m"
+        };
+        println!(
+            "  {}Overall: {:.1}%\x1B[0m ({}/{})",
+            overall_color, overall, total_executed, total_executable
+        );
+        println!();
+    }
 
     if failed > 0 {
         std::process::exit(1);

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -189,23 +189,10 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>, coverage: bool) {
                 }
             }
         }
-        if coverage {
-            if let Some(ref cov) = interpreter.coverage {
-                let executable_lines = source
-                    .lines()
-                    .enumerate()
-                    .filter(|(_, line)| {
-                        let trimmed = line.trim();
-                        !trimmed.is_empty()
-                            && !trimmed.starts_with("//")
-                            && !trimmed.starts_with("/*")
-                            && trimmed != "}"
-                            && trimmed != "{"
-                    })
-                    .count();
-                let executed = cov.len();
-                coverage_data.push((path_str.clone(), executable_lines, executed));
-            }
+        if let Some(ref cov) = interpreter.coverage {
+            let executable_set = executable_line_set(&source);
+            let executed = cov.intersection(&executable_set).count();
+            coverage_data.push((path_str.clone(), executable_set.len(), executed));
         }
 
         println!();
@@ -231,7 +218,7 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>, coverage: bool) {
             total_executable += executable;
             total_executed += executed;
             let pct = if *executable > 0 {
-                (*executed as f64 / *executable as f64 * 100.0).min(100.0)
+                *executed as f64 / *executable as f64 * 100.0
             } else {
                 100.0
             };
@@ -248,7 +235,7 @@ pub fn run_tests(test_dir: &str, filter: Option<&str>, coverage: bool) {
             );
         }
         let overall = if total_executable > 0 {
-            (total_executed as f64 / total_executable as f64 * 100.0).min(100.0)
+            total_executed as f64 / total_executable as f64 * 100.0
         } else {
             100.0
         };
@@ -303,6 +290,38 @@ fn find_test_functions(program: &Program) -> Vec<TestInfo> {
         }
     }
     tests
+}
+
+/// Build a set of 1-indexed line numbers considered executable.
+/// Excludes blank lines, single-line comments, multi-line comment blocks, and lone braces.
+fn executable_line_set(source: &str) -> std::collections::HashSet<usize> {
+    let mut set = std::collections::HashSet::new();
+    let mut in_block_comment = false;
+    for (i, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        if in_block_comment {
+            if let Some(pos) = trimmed.find("*/") {
+                in_block_comment = false;
+                // If there's code after the closing */, count this line
+                let after = trimmed[pos + 2..].trim();
+                if !after.is_empty() {
+                    set.insert(i + 1);
+                }
+            }
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed == "}" {
+            continue;
+        }
+        set.insert(i + 1); // 1-indexed to match parser line numbers
+    }
+    set
 }
 
 fn find_hook_function(program: &Program, hook_name: &str) -> Option<String> {


### PR DESCRIPTION
## Summary

- Add `--coverage` flag to `forge test` command
- Track executed source lines during test runs via interpreter coverage set
- Report per-file and overall line coverage with color-coded output
- Green (≥80%), yellow (≥50%), red (<50%)
- Excludes blank lines, comments, and lone braces from executable line count

## Test plan

- [x] 940 tests pass
- [x] `forge test` without `--coverage` works unchanged
- [x] `forge test --coverage` displays coverage report after test results