### PR TITLE
feat: forge build --aot for bytecode-embedded native binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **VM `ask` expression** — `ask "prompt"` calls the LLM API (OpenAI-compatible) in VM mode. Requires `FORGE_AI_KEY` or `OPENAI_API_KEY` environment variable.
 - **VM `freeze` expression** — `freeze expr` wraps values as immutable in VM mode. `SetField` on frozen values returns a runtime error.
 - **Cross-file LSP** — go-to-definition and find-references now work across files. Imported symbols resolve to their source file via `import` statement following. Find-references searches imported files and sibling `.fg` files in the same directory. Import statements now appear in document symbols.
+- **`forge build --aot`** — compiles Forge source to bytecode and embeds it in a native binary. Unlike `--native` (which embeds raw source), `--aot` embeds serialized bytecode for faster startup and no source exposure. The binary still requires the Forge VM runtime at execution time.
 
 ## [0.6.0] - 2026-04-11
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,9 +132,12 @@ enum Command {
     },
     /// Compile Forge source to bytecode
     Build {
-        /// Emit a native launcher executable that shells into the Forge runtime
-        #[arg(long)]
+        /// Emit a native launcher that embeds source and shells into the Forge runtime
+        #[arg(long, conflicts_with = "aot")]
         native: bool,
+        /// Compile to bytecode and embed in a native binary (no source exposure)
+        #[arg(long, conflicts_with = "native")]
+        aot: bool,
         /// Source file to compile
         file: PathBuf,
     },
@@ -272,7 +275,7 @@ async fn main() {
         Some(Command::New { name }) => {
             scaffold::create_project(&name);
         }
-        Some(Command::Build { file, native }) => {
+        Some(Command::Build { file, native, aot }) => {
             let path_str = file.display().to_string();
             let source = match fs::read_to_string(&file) {
                 Ok(s) => s,
@@ -287,7 +290,9 @@ async fn main() {
                     process::exit(1);
                 }
             };
-            if native {
+            if aot {
+                compile_to_native_aot(&source, &path_str, &file, strict);
+            } else if native {
                 compile_to_native_launcher(&source, &path_str, &file, strict);
             } else {
                 compile_to_bytecode(&source, &path_str, &file, strict);
@@ -826,6 +831,50 @@ fn compile_to_native_launcher(source: &str, filename: &str, file_path: &PathBuf,
                 "Built native launcher {} -> {}\n  runtime: Forge interpreter/VM required at execution time",
                 filename,
                 output_path.display()
+            );
+        }
+        Err(message) => {
+            eprintln!("{}", errors::format_simple_error(&message));
+            process::exit(1);
+        }
+    }
+}
+
+fn compile_to_native_aot(source: &str, filename: &str, file_path: &PathBuf, strict: bool) {
+    let (program, warnings) = match prepare_program(source, strict) {
+        Ok(prepared) => prepared,
+        Err(err) => print_frontend_error(source, filename, err),
+    };
+    emit_type_warnings(&warnings);
+
+    if let Err(message) = ensure_vm_compatible(&program, "AOT build") {
+        eprintln!("{}", errors::format_simple_error(&message));
+        process::exit(1);
+    }
+
+    let chunk = match vm::compiler::compile(&program) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{}", errors::format_simple_error(&e.message));
+            process::exit(1);
+        }
+    };
+
+    let bytecode = match vm::serialize::serialize_chunk(&chunk) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("{}", errors::format_simple_error(&e.message));
+            process::exit(1);
+        }
+    };
+
+    match native::build_native_aot(&bytecode, file_path) {
+        Ok(output_path) => {
+            println!(
+                "Built AOT binary {} -> {}\n  bytecode embedded ({} bytes, no source exposure)\n  runtime: Forge VM required at execution time",
+                filename,
+                output_path.display(),
+                bytecode.len()
             );
         }
         Err(message) => {

--- a/src/native.rs
+++ b/src/native.rs
@@ -439,6 +439,8 @@ mod tests {
         // Must use .fgc extension for temp file
         assert!(c_source.contains(".fgc"));
         assert!(c_source.contains("forge-aot-"));
+        // Must NOT contain the source-embedding array name
+        assert!(!c_source.contains("FORGE_PROGRAM[]"));
     }
 
     #[cfg(unix)]

--- a/src/native.rs
+++ b/src/native.rs
@@ -58,6 +58,57 @@ pub fn build_native_launcher(source: &str, source_path: &Path) -> Result<PathBuf
     }
 }
 
+pub fn build_native_aot(bytecode: &[u8], source_path: &Path) -> Result<PathBuf, String> {
+    #[cfg(not(unix))]
+    {
+        let _ = bytecode;
+        let _ = source_path;
+        return Err("--aot is currently supported on Unix-like systems only".to_string());
+    }
+
+    #[cfg(unix)]
+    {
+        let output_path = native_output_path(source_path);
+        let default_forge_bin = env::var("FORGE_NATIVE_FORGE_BIN")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                env::current_exe()
+                    .ok()
+                    .map(|path| path.display().to_string())
+            })
+            .unwrap_or_else(|| "forge".to_string());
+
+        let build_id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| format!("failed to create AOT timestamp: {}", e))?
+            .as_nanos();
+        let c_path =
+            env::temp_dir().join(format!("forge-aot-{}-{}.c", std::process::id(), build_id));
+        let c_source = aot_launcher_c_source(bytecode, &default_forge_bin);
+        fs::write(&c_path, c_source)
+            .map_err(|e| format!("failed to write AOT launcher source: {}", e))?;
+
+        let status = Command::new("cc")
+            .arg("-O2")
+            .arg(&c_path)
+            .arg("-o")
+            .arg(&output_path)
+            .status()
+            .map_err(|e| format!("failed to invoke C compiler for --aot: {}", e))?;
+        let _ = fs::remove_file(&c_path);
+
+        if !status.success() {
+            return Err(format!(
+                "AOT launcher compilation failed for '{}'",
+                output_path.display()
+            ));
+        }
+
+        Ok(output_path)
+    }
+}
+
 pub fn native_output_path(source_path: &Path) -> PathBuf {
     #[cfg(windows)]
     {
@@ -192,6 +243,128 @@ int main(int argc, char **argv) {{
     )
 }
 
+fn aot_launcher_c_source(bytecode: &[u8], default_forge_bin: &str) -> String {
+    let byte_list = bytecode
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        r#"#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static const unsigned char FORGE_BYTECODE[] = {{ {byte_list} }};
+static const size_t FORGE_BYTECODE_LEN = sizeof(FORGE_BYTECODE);
+static const char *DEFAULT_FORGE_BIN = "{default_forge_bin}";
+
+int main(int argc, char **argv) {{
+    char tmp_template[] = "/tmp/forge-aot-XXXXXX";
+    int fd = mkstemp(tmp_template);
+    if (fd == -1) {{
+        perror("mkstemp");
+        return 1;
+    }}
+
+    /* Rename to .fgc so forge recognizes it as compiled bytecode */
+    char program_path[sizeof(tmp_template) + 5];
+    if (snprintf(program_path, sizeof(program_path), "%s.fgc", tmp_template) < 0) {{
+        perror("snprintf");
+        close(fd);
+        unlink(tmp_template);
+        return 1;
+    }}
+    if (rename(tmp_template, program_path) != 0) {{
+        perror("rename");
+        close(fd);
+        unlink(tmp_template);
+        return 1;
+    }}
+
+    /* Write bytecode through the fd obtained from mkstemp (avoids TOCTOU) */
+    FILE *program = fdopen(fd, "wb");
+    if (!program) {{
+        perror("fdopen");
+        close(fd);
+        unlink(program_path);
+        return 1;
+    }}
+    if (fwrite(FORGE_BYTECODE, 1, FORGE_BYTECODE_LEN, program) != FORGE_BYTECODE_LEN) {{
+        perror("fwrite");
+        fclose(program);
+        unlink(program_path);
+        return 1;
+    }}
+    if (fclose(program) != 0) {{
+        perror("fclose");
+        unlink(program_path);
+        return 1;
+    }}
+
+    const char *forge_bin = getenv("FORGE_NATIVE_FORGE_BIN");
+    if (!forge_bin || !forge_bin[0]) {{
+        forge_bin = DEFAULT_FORGE_BIN;
+    }}
+
+    char **args = calloc((size_t)argc + 3, sizeof(char *));
+    if (!args) {{
+        fprintf(stderr, "calloc failed\n");
+        unlink(program_path);
+        return 1;
+    }}
+
+    args[0] = (char *)forge_bin;
+    args[1] = "run";
+    args[2] = program_path;
+    for (int i = 1; i < argc; ++i) {{
+        args[i + 2] = argv[i];
+    }}
+
+    pid_t child = fork();
+    if (child == 0) {{
+        execv(forge_bin, args);
+        if (strcmp(forge_bin, "forge") != 0) {{
+            args[0] = "forge";
+            execvp("forge", args);
+        }}
+        perror("exec forge");
+        _exit(127);
+    }}
+    if (child < 0) {{
+        perror("fork");
+        unlink(program_path);
+        free(args);
+        return 1;
+    }}
+
+    int status = 0;
+    if (waitpid(child, &status, 0) < 0) {{
+        perror("waitpid");
+        unlink(program_path);
+        free(args);
+        return 1;
+    }}
+
+    unlink(program_path);
+    free(args);
+    if (WIFEXITED(status)) {{
+        return WEXITSTATUS(status);
+    }}
+    if (WIFSIGNALED(status)) {{
+        return 128 + WTERMSIG(status);
+    }}
+    return 1;
+}}
+"#,
+        byte_list = byte_list,
+        default_forge_bin = c_string_escape(default_forge_bin)
+    )
+}
+
 fn c_string_escape(value: &str) -> String {
     value
         .chars()
@@ -244,6 +417,51 @@ mod tests {
         std::fs::write(&source_path, "println(\"hi\")").unwrap();
 
         let output_path = build_native_launcher("println(\"hi\")", &source_path).unwrap();
+        assert!(output_path.exists());
+        let metadata = std::fs::metadata(&output_path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert!(metadata.permissions().mode() & 0o111 != 0);
+        }
+
+        let _ = std::fs::remove_file(output_path);
+        let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn aot_launcher_source_embeds_bytecode_not_source() {
+        let bytecode: Vec<u8> = vec![0xF0, 0x01, 0x02, 0x03, 42, 99];
+        let c_source = aot_launcher_c_source(&bytecode, "/tmp/forge-bin");
+        // Must contain bytecode array, not source text
+        assert!(c_source.contains("static const unsigned char FORGE_BYTECODE[]"));
+        assert!(c_source.contains("/tmp/forge-bin"));
+        // Must use .fgc extension for temp file
+        assert!(c_source.contains(".fgc"));
+        assert!(c_source.contains("forge-aot-"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_native_aot_emits_binary() {
+        if Command::new("cc").arg("--version").output().is_err() {
+            return;
+        }
+
+        let temp_root = std::env::temp_dir().join(format!(
+            "forge-aot-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_root).unwrap();
+        let source_path = temp_root.join("hello.fg");
+        std::fs::write(&source_path, "println(\"hi\")").unwrap();
+
+        // Fake bytecode — we only verify the binary is produced and executable
+        let bytecode = vec![0x00, 0x01, 0x02, 0x03];
+        let output_path = build_native_aot(&bytecode, &source_path).unwrap();
         assert!(output_path.exists());
         let metadata = std::fs::metadata(&output_path).unwrap();
         #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Adds `forge build --aot` flag that compiles source to bytecode and embeds it in a native C launcher
- Unlike `--native` (embeds raw source text), `--aot` embeds serialized bytecode — no source exposure, faster startup
- Mutually exclusive with `--native` via clap `conflicts_with`
- Calls `ensure_vm_compatible()` before compilation to catch unsupported features early
- The generated binary still requires the Forge VM runtime (`forge`) at execution time
- 2 new tests (AOT C source verification + binary emission)
- 942 tests passing

## Test plan
- [x] `cargo test` — 942 passing
- [x] `forge build --aot examples/hello.fg` produces executable
- [x] `forge build --native --aot` errors (mutual exclusion)
- [x] AOT binary doesn't contain source text

🤖 Generated with [Claude Code](https://claude.com/claude-code)