### PR TITLE
fix: add missing GC roots to prevent use-after-free

### DIFF
--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1954,6 +1954,30 @@ impl VM {
                 }
                 for frame in &self.frames {
                     roots.push(frame.closure);
+                    for gr in frame.open_upvalues.values() {
+                        roots.push(*gr);
+                    }
+                }
+                for methods in self.method_tables.values() {
+                    for v in methods.values() {
+                        if let Value::Obj(gr) = v {
+                            roots.push(*gr);
+                        }
+                    }
+                }
+                for methods in self.static_methods.values() {
+                    for v in methods.values() {
+                        if let Value::Obj(gr) = v {
+                            roots.push(*gr);
+                        }
+                    }
+                }
+                for defaults in self.struct_defaults.values() {
+                    for v in defaults.values() {
+                        if let Value::Obj(gr) = v {
+                            roots.push(*gr);
+                        }
+                    }
                 }
                 self.gc.collect(&roots);
             }


### PR DESCRIPTION
## Summary
- Adds `method_tables`, `static_methods`, `struct_defaults` values to GC root scanning
- Adds `open_upvalues` GcRefs from all call frames to root scanning
- Prevents use-after-free when GC collects objects still referenced by these structures

## Roadmap item
5A.2 from Phase 5 — Critical Fixes

## Test plan
- [x] All 950 tests pass
- [x] Defensive fix — use-after-free is non-deterministic, covered by existing test suite exercising method calls, struct defaults, and closures with upvalues