### PR TITLE
fix: add coverage tracking for top-level statements

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -656,6 +656,11 @@ impl Interpreter {
     pub fn run(&mut self, program: &Program) -> Result<Value, RuntimeError> {
         for spanned in &program.statements {
             self.current_line = spanned.line;
+            if let Some(ref mut cov) = self.coverage {
+                if spanned.line > 0 {
+                    cov.insert(spanned.line);
+                }
+            }
             match self.exec_stmt(&spanned.stmt) {
                 Ok(signal) => match signal {
                     Signal::Return(v) => return Ok(v),


### PR DESCRIPTION
## Summary
- Adds coverage line insertion to `run()` method, matching existing pattern in `exec_stmts()`
- Top-level statements now correctly appear in `forge test --coverage` reports

## Roadmap item
5A.4 from Phase 5 — Critical Fixes

## Test plan
- [x] All 950 tests pass
- [x] Coverage tracking now matches exec_stmts() pattern