### PR TITLE
fix: add debug_assert on SendableVM jit_cache emptiness

### DIFF
--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -857,6 +857,10 @@ impl VM {
             child.struct_defaults.insert(name.clone(), child_defaults);
         }
 
+        debug_assert!(
+            child.jit_cache.is_empty(),
+            "BUG: SendableVM must have empty jit_cache to be safely Send"
+        );
         SendableVM(child)
     }
 


### PR DESCRIPTION
## Summary
- Adds debug_assert ensuring forked VM jit_cache is empty before wrapping in SendableVM
- Guards the unsafe impl Send invariant at runtime in debug builds

## Roadmap item
5B.1 from Phase 5

## Test plan
- [x] All 950 tests pass
- [x] Assertion fires in debug builds if invariant is violated