### PR TITLE
perf: lazy register allocation in VM

### DIFF
--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -292,7 +292,7 @@ impl std::fmt::Display for VMError {
 impl VM {
     pub fn new() -> Self {
         let mut vm = Self {
-            registers: vec![Value::Null; MAX_REGISTERS],
+            registers: vec![Value::Null; 256],
             frames: Vec::with_capacity(MAX_FRAMES),
             globals: HashMap::new(),
             method_tables: HashMap::new(),
@@ -311,7 +311,7 @@ impl VM {
 
     pub fn with_profiling() -> Self {
         let mut vm = Self {
-            registers: vec![Value::Null; MAX_REGISTERS],
+            registers: vec![Value::Null; 256],
             frames: Vec::with_capacity(MAX_FRAMES),
             globals: HashMap::new(),
             method_tables: HashMap::new(),
@@ -940,12 +940,19 @@ impl VM {
         };
         let closure_ref = self.gc.alloc(ObjKind::Closure(closure));
         let new_base = self.frames.last().map(|f| f.base + 256).unwrap_or(0);
-        if new_base + 256 > MAX_REGISTERS {
+        if self.frames.len() >= MAX_FRAMES {
             return Err(VMError::new("stack overflow"));
         }
+        self.ensure_registers(new_base + 256);
         self.frames.push(CallFrame::new(closure_ref, new_base));
         let boundary = self.frames.len() - 1;
         self.run_until(boundary)
+    }
+
+    fn ensure_registers(&mut self, needed: usize) {
+        if needed > self.registers.len() {
+            self.registers.resize(needed, Value::Null);
+        }
     }
 
     fn earliest_expired_timeout(&self) -> Option<(usize, TimeoutGuard)> {
@@ -2087,9 +2094,10 @@ impl VM {
 
                         let arity = chunk.arity as usize;
                         let new_base = self.frames.last().map(|f| f.base + 256).unwrap_or(0);
-                        if new_base + 256 > MAX_REGISTERS {
+                        if self.frames.len() >= MAX_FRAMES {
                             return Err(VMError::new("stack overflow"));
                         }
+                        self.ensure_registers(new_base + 256);
 
                         for (i, arg) in args.iter().enumerate() {
                             if i < arity {


### PR DESCRIPTION
## Summary
- Start with 256 registers (~6KB) instead of 65,536 (~1.5MB) per VM instance
- Registers grow on demand via ensure_registers() at call sites
- Stack overflow checks frame count vs MAX_FRAMES (correct semantic check)

## Roadmap item
5B.3 from Phase 5

## Test plan
- [x] All 950 tests pass
- [x] Recursive tests (fib(30)) exercise deep call stacks with dynamic growth