### PR TITLE
fix: internal timing and fair array benchmark

### DIFF
--- a/benchmarks/bench_array.fg
+++ b/benchmarks/bench_array.fg
@@ -1,4 +1,6 @@
 // Benchmark: Array operations - create 100,000 items, map, filter, reduce
+let start = time.elapsed()
+
 let mut arr = []
 let mut i = 0
 while i < 100000 {
@@ -17,4 +19,6 @@ println("Filter done, length = {len(evens)}")
 
 // Reduce: sum
 let total = reduce(evens, 0, fn(acc, x) { return acc + x })
+let elapsed = time.elapsed() - start
 println("Reduce sum = {total}")
+println("Time: {elapsed}ms")

--- a/benchmarks/bench_array.py
+++ b/benchmarks/bench_array.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 # Benchmark: Array operations - create 100,000 items, map, filter, reduce
+import time
 from functools import reduce
 
-arr = list(range(100000))
+start = time.time()
+
+# Build array with a loop (fair comparison — no C-level range())
+arr = []
+for i in range(100000):
+    arr.append(i)
 print(f"Array created, length = {len(arr)}")
 
 # Map: double each value
@@ -15,4 +21,6 @@ print(f"Filter done, length = {len(evens)}")
 
 # Reduce: sum
 total = reduce(lambda acc, x: acc + x, evens, 0)
+elapsed = (time.time() - start) * 1000
 print(f"Reduce sum = {total}")
+print(f"Time: {elapsed:.0f}ms")

--- a/benchmarks/bench_factorial.fg
+++ b/benchmarks/bench_factorial.fg
@@ -6,11 +6,14 @@ fn factorial(n) {
     return n * factorial(n - 1)
 }
 
+let start = time.elapsed()
 let mut i = 0
 let mut result = 0
 while i < 10000 {
     result = factorial(20)
     i = i + 1
 }
+let elapsed = time.elapsed() - start
 println("factorial(20) = {result}")
 println("Computed 10000 times")
+println("Time: {elapsed}ms")

--- a/benchmarks/bench_factorial.py
+++ b/benchmarks/bench_factorial.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 # Benchmark: Factorial(20) called 10,000 times
+import time
 
 def factorial(n):
     if n <= 1:
         return 1
     return n * factorial(n - 1)
 
+start = time.time()
 result = 0
 for i in range(10000):
     result = factorial(20)
+elapsed = (time.time() - start) * 1000
 print(f"factorial(20) = {result}")
 print("Computed 10000 times")
+print(f"Time: {elapsed:.0f}ms")

--- a/benchmarks/bench_fib.fg
+++ b/benchmarks/bench_fib.fg
@@ -6,5 +6,8 @@ fn fib(n) {
     return fib(n - 1) + fib(n - 2)
 }
 
+let start = time.elapsed()
 let result = fib(30)
+let elapsed = time.elapsed() - start
 println("fib(30) = {result}")
+println("Time: {elapsed}ms")

--- a/benchmarks/bench_fib.py
+++ b/benchmarks/bench_fib.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 # Benchmark: Recursive Fibonacci fib(30)
+import time
 
 def fib(n):
     if n <= 1:
         return n
     return fib(n - 1) + fib(n - 2)
 
+start = time.time()
 result = fib(30)
+elapsed = (time.time() - start) * 1000
 print(f"fib(30) = {result}")
+print(f"Time: {elapsed:.0f}ms")

--- a/benchmarks/bench_loop.fg
+++ b/benchmarks/bench_loop.fg
@@ -1,8 +1,11 @@
 // Benchmark: Loop - sum 1 to 1,000,000
+let start = time.elapsed()
 let mut total = 0
 let mut i = 1
 while i <= 1000000 {
     total = total + i
     i = i + 1
 }
+let elapsed = time.elapsed() - start
 println("Sum = {total}")
+println("Time: {elapsed}ms")

--- a/benchmarks/bench_loop.py
+++ b/benchmarks/bench_loop.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 # Benchmark: Loop - sum 1 to 1,000,000
+import time
 
+start = time.time()
 total = 0
 for i in range(1, 1000001):
     total += i
+elapsed = (time.time() - start) * 1000
 print(f"Sum = {total}")
+print(f"Time: {elapsed:.0f}ms")

--- a/benchmarks/bench_string.fg
+++ b/benchmarks/bench_string.fg
@@ -1,4 +1,5 @@
 // Benchmark: String concatenation - 10,000 strings
+let start = time.elapsed()
 let mut s = ""
 let mut i = 0
 while i < 10000 {
@@ -6,4 +7,6 @@ while i < 10000 {
     i = i + 1
 }
 let length = len(s)
+let elapsed = time.elapsed() - start
 println("String length = {length}")
+println("Time: {elapsed}ms")

--- a/benchmarks/bench_string.py
+++ b/benchmarks/bench_string.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 # Benchmark: String concatenation - 10,000 strings
+import time
 
+start = time.time()
 s = ""
 for i in range(10000):
     s = s + "a"
+elapsed = (time.time() - start) * 1000
 print(f"String length = {len(s)}")
+print(f"Time: {elapsed:.0f}ms")

--- a/benchmarks/run_benchmarks.sh
+++ b/benchmarks/run_benchmarks.sh
@@ -22,6 +22,8 @@ echo "Python: $(python3 --version 2>&1)"
 echo "Date: $(date)"
 echo "Platform: $(uname -ms)"
 echo ""
+echo "All times are self-reported (internal timing)."
+echo ""
 
 run_benchmark() {
     local name="$1"
@@ -32,35 +34,23 @@ run_benchmark() {
     echo "  Benchmark: $name"
     echo "----------------------------------------------"
 
-    # Run Forge benchmark
+    # Run Forge VM (default)
     echo ""
-    echo "  [Forge]"
-    FORGE_START=$(python3 -c "import time; print(time.time())")
+    echo "  [Forge VM]"
     $FORGE run "$fg_file" 2>&1 | sed 's/^/    /'
-    FORGE_END=$(python3 -c "import time; print(time.time())")
-    FORGE_TIME=$(python3 -c "print(f'{$FORGE_END - $FORGE_START:.3f}s')")
-    echo "    Time: $FORGE_TIME"
+
+    # Run Forge interpreter
+    echo ""
+    echo "  [Forge --interp]"
+    $FORGE run --interp "$fg_file" 2>&1 | sed 's/^/    /'
 
     # Run Python benchmark
     echo ""
     echo "  [Python]"
-    PY_START=$(python3 -c "import time; print(time.time())")
     python3 "$py_file" 2>&1 | sed 's/^/    /'
-    PY_END=$(python3 -c "import time; print(time.time())")
-    PY_TIME=$(python3 -c "print(f'{$PY_END - $PY_START:.3f}s')")
-    echo "    Time: $PY_TIME"
 
     echo ""
-
-    # Store results for summary
-    FORGE_TIMES+=("$FORGE_TIME")
-    PY_TIMES+=("$PY_TIME")
-    BENCH_NAMES+=("$name")
 }
-
-FORGE_TIMES=()
-PY_TIMES=()
-BENCH_NAMES=()
 
 run_benchmark "Fibonacci (recursive fib(30))" "$BENCH_DIR/bench_fib.fg" "$BENCH_DIR/bench_fib.py"
 run_benchmark "Loop (sum 1 to 1,000,000)" "$BENCH_DIR/bench_loop.fg" "$BENCH_DIR/bench_loop.py"
@@ -68,15 +58,7 @@ run_benchmark "String concat (10,000 strings)" "$BENCH_DIR/bench_string.fg" "$BE
 run_benchmark "Array ops (100K map/filter/reduce)" "$BENCH_DIR/bench_array.fg" "$BENCH_DIR/bench_array.py"
 run_benchmark "Factorial(20) x 10,000" "$BENCH_DIR/bench_factorial.fg" "$BENCH_DIR/bench_factorial.py"
 
-echo ""
 echo "=============================================="
-echo "  SUMMARY"
-echo "=============================================="
-echo ""
-printf "%-35s %12s %12s\n" "Benchmark" "Forge" "Python"
-printf "%-35s %12s %12s\n" "-----------------------------------" "------------" "------------"
-for i in "${!BENCH_NAMES[@]}"; do
-    printf "%-35s %12s %12s\n" "${BENCH_NAMES[$i]}" "${FORGE_TIMES[$i]}" "${PY_TIMES[$i]}"
-done
-echo ""
+echo "  All benchmarks use internal timing."
+echo "  Compare the 'Time:' lines above."
 echo "=============================================="


### PR DESCRIPTION
## Summary
- All benchmarks now use internal timing (time.elapsed/time.time) instead of external Python process timing
- Array benchmark Python uses append loop instead of list(range()) for fair comparison
- Runner script tests both VM and interpreter modes

## Roadmap item
5B.4 from Phase 5

## Test plan
- [x] All 950 tests pass
- [x] All benchmark files have consistent Time: output format