### PR TITLE
feat: add Rust/Go/Node.js fib(30) benchmarks

### DIFF
--- a/benchmarks/bench_fib.go
+++ b/benchmarks/bench_fib.go
@@ -1,0 +1,23 @@
+// Benchmark: Recursive Fibonacci fib(30) — Go
+// Run: go run bench_fib.go
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func fib(n int) int {
+	if n <= 1 {
+		return n
+	}
+	return fib(n-1) + fib(n-2)
+}
+
+func main() {
+	start := time.Now()
+	result := fib(30)
+	elapsed := time.Since(start).Milliseconds()
+	fmt.Printf("fib(30) = %d\n", result)
+	fmt.Printf("Time: %dms\n", elapsed)
+}

--- a/benchmarks/bench_fib.js
+++ b/benchmarks/bench_fib.js
@@ -1,0 +1,13 @@
+// Benchmark: Recursive Fibonacci fib(30) — Node.js
+// Run: node bench_fib.js
+
+function fib(n) {
+  if (n <= 1) return n;
+  return fib(n - 1) + fib(n - 2);
+}
+
+const start = performance.now();
+const result = fib(30);
+const elapsed = Math.round(performance.now() - start);
+console.log(`fib(30) = ${result}`);
+console.log(`Time: ${elapsed}ms`);

--- a/benchmarks/bench_fib.rs
+++ b/benchmarks/bench_fib.rs
@@ -1,0 +1,18 @@
+// Benchmark: Recursive Fibonacci fib(30) — Rust
+// Compile: rustc -O bench_fib.rs -o bench_fib_rs
+use std::time::Instant;
+
+fn fib(n: i64) -> i64 {
+    if n <= 1 {
+        return n;
+    }
+    fib(n - 1) + fib(n - 2)
+}
+
+fn main() {
+    let start = Instant::now();
+    let result = fib(30);
+    let elapsed = start.elapsed().as_millis();
+    println!("fib(30) = {result}");
+    println!("Time: {elapsed}ms");
+}


### PR DESCRIPTION
## Summary
- Adds bench_fib.rs, bench_fib.go, bench_fib.js for cross-language fib(30) comparison
- All use internal timing matching the existing Forge/Python benchmarks
- Enables independent verification of landing page performance claims

## Roadmap item
5B.5 from Phase 5

## Test plan
- [x] All 950 tests pass
- [x] Each file includes compile/run instructions in comments