### PR TITLE
fix: len() returns char count not byte count for VM strings

### DIFF
--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -412,7 +412,7 @@ impl VM {
                 Some(v) => {
                     let len = match v {
                         Value::Obj(r) => self.gc.get(*r).map_or(0, |o| match &o.kind {
-                            ObjKind::String(s) => s.len() as i64,
+                            ObjKind::String(s) => s.chars().count() as i64,
                             ObjKind::Array(a) => a.len() as i64,
                             ObjKind::Object(o) => o.len() as i64,
                             _ => 0,

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1602,7 +1602,7 @@ impl VM {
                             Value::Obj(r) => {
                                 if let Some(obj) = self.gc.get(*r) {
                                     match &obj.kind {
-                                        ObjKind::String(s) => s.len() as i64,
+                                        ObjKind::String(s) => s.chars().count() as i64,
                                         ObjKind::Array(a) => a.len() as i64,
                                         ObjKind::Object(o) => o.len() as i64,
                                         _ => 0,


### PR DESCRIPTION
## Summary
- OpCode::Len and len() builtin now use chars().count() instead of len()
- Fixes VM parity with interpreter for multi-byte Unicode strings

## Roadmap item
5C.1 from Phase 5

## Test plan
- [x] All 950 tests pass