### PR TITLE
fix: add Object equality to VM GcObject::equals

### DIFF
--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -271,6 +271,11 @@ impl GcObject {
             (ObjKind::Array(a), ObjKind::Array(b)) => {
                 a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.equals(y, gc))
             }
+            (ObjKind::Object(a), ObjKind::Object(b)) => {
+                a.len() == b.len()
+                    && a.iter()
+                        .all(|(k, v)| b.get(k).map_or(false, |bv| v.equals(bv, gc)))
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary
- Objects now compare by key-value equality instead of always returning false
- Matches interpreter behavior for == on objects

## Roadmap item
5C.2 from Phase 5

## Test plan
- [x] All 950 tests pass