### PR TITLE
fix: add register overflow bounds check in compiler

### DIFF
--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -95,6 +95,9 @@ impl Compiler {
     }
 
     fn alloc_reg(&mut self) -> u8 {
+        if self.next_register == 255 {
+            panic!("BUG: compiler register overflow — function uses more than 255 registers");
+        }
         let r = self.next_register;
         self.next_register += 1;
         if self.next_register > self.max_register {


### PR DESCRIPTION
## Summary
- Checks for register overflow (255) in alloc_reg() before incrementing
- Panics with clear message instead of silent u8 wraparound producing corrupt bytecode

## Roadmap item
5C.7 from Phase 5

## Test plan
- [x] All 950 tests pass
- [x] No existing code hits the limit (max registers used is well under 255 per function)