### PR TITLE
fix: interpreter len() returns char count, not byte count

### DIFF
--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -25,7 +25,7 @@ impl Interpreter {
                 Ok(Value::Null)
             }
             "len" => match args.first() {
-                Some(Value::String(s)) => Ok(Value::Int(s.len() as i64)),
+                Some(Value::String(s)) => Ok(Value::Int(s.chars().count() as i64)),
                 Some(Value::Array(a)) => Ok(Value::Int(a.len() as i64)),
                 Some(Value::Object(o)) => Ok(Value::Int(o.len() as i64)),
                 _ => Err(RuntimeError::new("len() requires string, array, or object")),
@@ -996,7 +996,7 @@ impl Interpreter {
             "count" => match (args.first(), args.get(1)) {
                 (Some(Value::String(s)), Some(Value::String(substr))) => {
                     if substr.is_empty() {
-                        return Ok(Value::Int((s.len() + 1) as i64));
+                        return Ok(Value::Int((s.chars().count() + 1) as i64));
                     }
                     Ok(Value::Int(s.matches(substr.as_str()).count() as i64))
                 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1877,7 +1877,7 @@ impl Interpreter {
                         )))
                     }
                     Value::String(s) => match field.as_str() {
-                        "len" => Ok(Value::Int(s.len() as i64)),
+                        "len" => Ok(Value::Int(s.chars().count() as i64)),
                         "upper" => Ok(Value::String(s.to_uppercase())),
                         "lower" => Ok(Value::String(s.to_lowercase())),
                         "trim" => Ok(Value::String(s.trim().to_string())),
@@ -2177,7 +2177,7 @@ impl Interpreter {
                                     return Ok(Value::String(s.trim_start().to_string()))
                                 }
                                 "trim_end" => return Ok(Value::String(s.trim_end().to_string())),
-                                "len" => return Ok(Value::Int(s.len() as i64)),
+                                "len" => return Ok(Value::Int(s.chars().count() as i64)),
                                 "is_empty" => return Ok(Value::Bool(s.is_empty())),
                                 "is_numeric" => {
                                     return Ok(Value::Bool(

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -2386,7 +2386,7 @@ impl VM {
                 let s = self.get_string_arg(&args, 0)?;
                 let substr = self.get_string_arg(&args, 1)?;
                 if substr.is_empty() {
-                    return Ok(Value::Int((s.len() + 1) as i64));
+                    return Ok(Value::Int((s.chars().count() + 1) as i64));
                 }
                 Ok(Value::Int(s.matches(&*substr).count() as i64))
             }


### PR DESCRIPTION
## Summary
- Fixes interpreter `len()` to return character count (`s.chars().count()`) instead of byte count (`s.len()`), matching the VM behavior fixed in PR #31
- Four call sites fixed: builtin function, two method dispatch paths, and `count("")` edge case
- Roadmap item 6A.1

## Test plan
- [x] `cargo test` — 950 tests pass
- [x] Non-ASCII strings (emoji, accented chars) now return consistent values across interpreter and VM