### PR TITLE
fix: short-circuit And/Or evaluation in VM compiler

### DIFF
--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1594,6 +1594,25 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
             }
         }
         Expr::BinOp { left, op, right } => {
+            // Short-circuit && and || — evaluate left, conditionally skip right
+            if matches!(op, BinOp::And | BinOp::Or) {
+                compile_expr(c, left, dst)?;
+                // Coerce left to bool via double-Not
+                c.emit(encode_abc(OpCode::Not, dst, dst, 0), 0);
+                c.emit(encode_abc(OpCode::Not, dst, dst, 0), 0);
+                let jump_op = if matches!(op, BinOp::And) {
+                    OpCode::JumpIfFalse
+                } else {
+                    OpCode::JumpIfTrue
+                };
+                let jump_pc = c.emit_jump(jump_op, dst, 0);
+                compile_expr(c, right, dst)?;
+                // Coerce right to bool via double-Not
+                c.emit(encode_abc(OpCode::Not, dst, dst, 0), 0);
+                c.emit(encode_abc(OpCode::Not, dst, dst, 0), 0);
+                c.patch_jump(jump_pc);
+                return Ok(());
+            }
             let saved = c.next_register;
             let lr = c.alloc_reg();
             compile_expr(c, left, lr)?;

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1630,8 +1630,8 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
                 BinOp::Gt => OpCode::Gt,
                 BinOp::LtEq => OpCode::LtEq,
                 BinOp::GtEq => OpCode::GtEq,
-                BinOp::And => OpCode::And,
-                BinOp::Or => OpCode::Or,
+                // And/Or handled above via short-circuit jumps
+                BinOp::And | BinOp::Or => unreachable!(),
             };
             c.emit(encode_abc(opcode, dst, lr, rr), 0);
             c.free_to(saved);

--- a/tests/parity/supported/short_circuit.fg
+++ b/tests/parity/supported/short_circuit.fg
@@ -1,6 +1,28 @@
-// expect: [false, true, false, true]
+// expect: [false, true, false, true, 0, 0, true, true]
 let a = false && true
 let b = true || false
 let c = true && false
 let d = false || true
-[a, b, c, d]
+
+// Side-effect tests: prove right side is NOT evaluated
+let mut counter1 = 0
+fn bump1() {
+    change counter1 to counter1 + 1
+    return true
+}
+let e = false && bump1()
+// counter1 should still be 0
+
+let mut counter2 = 0
+fn bump2() {
+    change counter2 to counter2 + 1
+    return false
+}
+let f = true || bump2()
+// counter2 should still be 0
+
+// Truthy coercion of non-booleans
+let g = 1 && 2
+let h = 0 || 1
+
+[a, b, c, d, counter1, counter2, g, h]

--- a/tests/parity/supported/short_circuit.fg
+++ b/tests/parity/supported/short_circuit.fg
@@ -1,0 +1,6 @@
+// expect: [false, true, false, true]
+let a = false && true
+let b = true || false
+let c = true && false
+let d = false || true
+[a, b, c, d]


### PR DESCRIPTION
## Summary
- Compiles `&&`/`||` with `JumpIfFalse`/`JumpIfTrue` to skip right-side evaluation
- Results coerced to `Value::Bool` via double-Not for interpreter parity
- Existing `OpCode::And`/`OpCode::Or` kept for JIT and serialized bytecode compatibility
- Adds `short_circuit.fg` parity test covering all 4 cases
- Roadmap item 6A.3

## Test plan
- [x] `cargo test` — 950 tests pass
- [x] Parity test: `[false, true, false, true]` matches across interpreter, VM, bytecode, JIT