### PR TITLE
refactor: feature-gate PostgreSQL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,10 +69,10 @@ regex = "1"
 
 # === Database ===
 rusqlite = { version = "0.34", features = ["bundled"] }
-tokio-postgres = "0.7"
-tokio-postgres-rustls = "0.13"             # TLS for pg — consistent with rustls-everywhere policy
-rustls = "0.23"                            # shared with reqwest/tungstenite TLS config
-webpki-roots = "1"                         # root CA certs for pg TLS verification
+tokio-postgres = { version = "0.7", optional = true }
+tokio-postgres-rustls = { version = "0.13", optional = true }
+rustls = { version = "0.23", optional = true }
+webpki-roots = { version = "1", optional = true }
 mysql_async = { version = "0.34", default-features = false, features = ["rustls-tls"] }
 flate2 = "1"
 
@@ -87,8 +87,9 @@ cranelift-module = { version = "0.129", optional = true }
 cranelift-native = { version = "0.129", optional = true }
 
 [features]
-default = ["jit"]
+default = ["jit", "postgres"]
 jit = ["cranelift-codegen", "cranelift-frontend", "cranelift-jit", "cranelift-module", "cranelift-native"]
+postgres = ["tokio-postgres", "tokio-postgres-rustls", "rustls", "webpki-roots"]
 
 [profile.dev]
 opt-level = 1

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1322,6 +1322,7 @@ impl Interpreter {
             _ if name.starts_with("log.") => {
                 crate::stdlib::log::call(name, args).map_err(|e| RuntimeError::new(&e))
             }
+            #[cfg(feature = "postgres")]
             _ if name.starts_with("pg.") => {
                 crate::stdlib::pg::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -480,6 +480,7 @@ impl Interpreter {
             .define("regex".to_string(), crate::stdlib::create_regex_module());
         self.env
             .define("log".to_string(), crate::stdlib::create_log_module());
+        #[cfg(feature = "postgres")]
         self.env
             .define("pg".to_string(), crate::stdlib::create_pg_module());
         self.env

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -12,6 +12,7 @@ pub mod log;
 pub mod math;
 pub mod mysql;
 pub mod npc;
+#[cfg(feature = "postgres")]
 pub mod pg;
 pub mod regex_module;
 pub mod term;
@@ -49,6 +50,7 @@ pub fn create_regex_module() -> Value {
 pub fn create_log_module() -> Value {
     log::create_module()
 }
+#[cfg(feature = "postgres")]
 pub fn create_pg_module() -> Value {
     pg::create_module()
 }

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -1507,6 +1507,7 @@ impl VM {
                     crate::stdlib::time::call(n, interp_args).map_err(|e| VMError::new(&e))?;
                 Ok(self.convert_interp_value(&result))
             }
+            #[cfg(feature = "postgres")]
             n if n.starts_with("pg.") => {
                 let interp_args = self.args_to_interp(&args);
                 let result =

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -724,17 +724,20 @@ impl VM {
             .insert("time".to_string(), Value::Obj(time_ref));
 
         // pg module
-        let mut pg_map = IndexMap::new();
-        for name in &["connect", "query", "execute", "close"] {
-            let full = format!("pg.{}", name);
-            let nr = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
-                name: full,
-                func: native_dispatch,
-            }));
-            pg_map.insert(name.to_string(), Value::Obj(nr));
+        #[cfg(feature = "postgres")]
+        {
+            let mut pg_map = IndexMap::new();
+            for name in &["connect", "query", "execute", "close"] {
+                let full = format!("pg.{}", name);
+                let nr = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
+                    name: full,
+                    func: native_dispatch,
+                }));
+                pg_map.insert(name.to_string(), Value::Obj(nr));
+            }
+            let pg_ref = self.gc.alloc(ObjKind::Object(pg_map));
+            self.globals.insert("pg".to_string(), Value::Obj(pg_ref));
         }
-        let pg_ref = self.gc.alloc(ObjKind::Object(pg_map));
-        self.globals.insert("pg".to_string(), Value::Obj(pg_ref));
 
         // jwt module
         let mut jwt_map = IndexMap::new();


### PR DESCRIPTION
## Summary
- Make PostgreSQL deps (`tokio-postgres`, `tokio-postgres-rustls`, `rustls`, `webpki-roots`) optional behind `postgres` cargo feature (enabled by default)
- Gate pg module registration, stdlib module, and dispatch arms
- Keep "pg" in import/autocomplete lists to prevent file resolution attempts

## Test plan
- [x] `cargo test` — 950 tests pass (all defaults)
- [x] `cargo test --no-default-features` — 871 tests pass (no jit, no pg)

Roadmap item: 6B.2