### PR TITLE
refactor: feature-gate MySQL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tokio-postgres = { version = "0.7", optional = true }
 tokio-postgres-rustls = { version = "0.13", optional = true }
 rustls = { version = "0.23", optional = true }
 webpki-roots = { version = "1", optional = true }
-mysql_async = { version = "0.34", default-features = false, features = ["rustls-tls"] }
+mysql_async = { version = "0.34", default-features = false, features = ["rustls-tls"], optional = true }
 flate2 = "1"
 
 # === JWT ===
@@ -87,9 +87,10 @@ cranelift-module = { version = "0.129", optional = true }
 cranelift-native = { version = "0.129", optional = true }
 
 [features]
-default = ["jit", "postgres"]
+default = ["jit", "postgres", "mysql"]
 jit = ["cranelift-codegen", "cranelift-frontend", "cranelift-jit", "cranelift-module", "cranelift-native"]
 postgres = ["tokio-postgres", "tokio-postgres-rustls", "rustls", "webpki-roots"]
+mysql = ["mysql_async"]
 
 [profile.dev]
 opt-level = 1

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1353,6 +1353,7 @@ impl Interpreter {
             _ if name.starts_with("jwt.") => {
                 crate::stdlib::jwt::call(name, args).map_err(|e| RuntimeError::new(&e))
             }
+            #[cfg(feature = "mysql")]
             _ if name.starts_with("mysql.") => {
                 crate::stdlib::mysql::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -501,6 +501,7 @@ impl Interpreter {
             .define("ws".to_string(), crate::stdlib::create_ws_module());
         self.env
             .define("jwt".to_string(), crate::stdlib::create_jwt_module());
+        #[cfg(feature = "mysql")]
         self.env
             .define("mysql".to_string(), crate::stdlib::create_mysql_module());
 

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -10,6 +10,7 @@ pub mod json_module;
 pub mod jwt;
 pub mod log;
 pub mod math;
+#[cfg(feature = "mysql")]
 pub mod mysql;
 pub mod npc;
 #[cfg(feature = "postgres")]
@@ -81,6 +82,7 @@ pub fn create_ws_module() -> Value {
 pub fn create_jwt_module() -> Value {
     jwt::create_module()
 }
+#[cfg(feature = "mysql")]
 pub fn create_mysql_module() -> Value {
     mysql::create_module()
 }

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -1520,6 +1520,7 @@ impl VM {
                     crate::stdlib::jwt::call(n, interp_args).map_err(|e| VMError::new(&e))?;
                 Ok(self.convert_interp_value(&result))
             }
+            #[cfg(feature = "mysql")]
             n if n.starts_with("mysql.") => {
                 let interp_args = self.args_to_interp(&args);
                 let result =

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -753,18 +753,21 @@ impl VM {
         self.globals.insert("jwt".to_string(), Value::Obj(jwt_ref));
 
         // mysql module
-        let mut mysql_map = IndexMap::new();
-        for name in &["connect", "query", "execute", "close"] {
-            let full = format!("mysql.{}", name);
-            let nr = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
-                name: full,
-                func: native_dispatch,
-            }));
-            mysql_map.insert(name.to_string(), Value::Obj(nr));
+        #[cfg(feature = "mysql")]
+        {
+            let mut mysql_map = IndexMap::new();
+            for name in &["connect", "query", "execute", "close"] {
+                let full = format!("mysql.{}", name);
+                let nr = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
+                    name: full,
+                    func: native_dispatch,
+                }));
+                mysql_map.insert(name.to_string(), Value::Obj(nr));
+            }
+            let mysql_ref = self.gc.alloc(ObjKind::Object(mysql_map));
+            self.globals
+                .insert("mysql".to_string(), Value::Obj(mysql_ref));
         }
-        let mysql_ref = self.gc.alloc(ObjKind::Object(mysql_map));
-        self.globals
-            .insert("mysql".to_string(), Value::Obj(mysql_ref));
 
         // Option prelude
         let mut none_obj = IndexMap::new();


### PR DESCRIPTION
## Summary
- Make `mysql_async` an optional dependency behind `mysql` cargo feature (enabled by default)
- Same pattern as PR #42 (postgres feature gate)
- Gate mysql module registration, stdlib module, and dispatch arms

## Test plan
- [x] `cargo test` — 950 tests pass (all defaults)
- [x] `cargo test --no-default-features` — 860 tests pass (no jit, no pg, no mysql)

Roadmap item: 6B.3