### PR TITLE
refactor: trim tokio features to minimal set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # === Async Runtime ===
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "net", "time", "io-util"] }
 
 # === HTTP Server (production-grade) ===
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
## Summary
- Replace tokio `"full"` with 7 specific features: `macros`, `rt`, `rt-multi-thread`, `sync`, `net`, `time`, `io-util`
- Removes unused tokio subsystems (fs, signal, process) from compilation

## Test plan
- [x] `cargo test` — 950 tests pass
- [x] `cargo test --no-default-features` — 860 tests pass

Roadmap item: 6B.4