### PR TITLE
fix: escape strings in JSON serialization

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,6 +8,28 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
+/// Escape a string for safe JSON embedding. Handles backslashes, quotes,
+/// newlines, tabs, carriage returns, and control characters.
+fn escape_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c < '\x20' => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// Thread-safe channel inner type
 #[derive(Debug)]
 pub struct ChannelInner {
@@ -125,7 +147,7 @@ impl Value {
             Value::Object(map) => {
                 let entries: Vec<String> = map
                     .iter()
-                    .map(|(k, v)| format!("\"{}\": {}", k, v.to_json_string()))
+                    .map(|(k, v)| format!("{}: {}", escape_json_string(k), v.to_json_string()))
                     .collect();
                 format!("{{ {} }}", entries.join(", "))
             }
@@ -133,7 +155,7 @@ impl Value {
                 let entries: Vec<String> = items.iter().map(|v| v.to_json_string()).collect();
                 format!("[{}]", entries.join(", "))
             }
-            Value::String(s) => format!("\"{}\"", s),
+            Value::String(s) => escape_json_string(s),
             Value::Int(n) => n.to_string(),
             Value::Float(n) => format!("{}", n),
             Value::Bool(b) => b.to_string(),
@@ -3233,7 +3255,6 @@ impl fmt::Display for RuntimeError {
         write!(f, "Runtime error: {}", self.message)
     }
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1853,11 +1853,12 @@ impl VM {
                         let url = std::env::var("FORGE_AI_URL").unwrap_or_else(|_| {
                             "https://api.openai.com/v1/chat/completions".to_string()
                         });
-                        let body = format!(
-                            r#"{{"model":"{}","messages":[{{"role":"user","content":"{}"}}],"max_tokens":1000}}"#,
-                            model,
-                            prompt_str.replace('\\', "\\\\").replace('"', "\\\"")
-                        );
+                        let body = serde_json::json!({
+                            "model": model,
+                            "messages": [{"role": "user", "content": prompt_str}],
+                            "max_tokens": 1000
+                        })
+                        .to_string();
                         let mut headers = std::collections::HashMap::new();
                         headers.insert("Authorization".to_string(), format!("Bearer {}", api_key));
                         headers.insert("Content-Type".to_string(), "application/json".to_string());

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -4,6 +4,27 @@ use indexmap::IndexMap;
 use std::fmt;
 use std::sync::Arc;
 
+/// Escape a string for safe JSON embedding.
+fn escape_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c < '\x20' => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// GC-free value representation for crossing thread boundaries.
 /// Used for spawn result slots and globals transfer during fork_for_spawn.
 #[derive(Clone)]
@@ -215,7 +236,7 @@ impl GcObject {
             ObjKind::Object(map) => {
                 let entries: Vec<String> = map
                     .iter()
-                    .map(|(k, v)| format!("\"{}\": {}", k, v.to_json_string(gc)))
+                    .map(|(k, v)| format!("{}: {}", escape_json_string(k), v.to_json_string(gc)))
                     .collect();
                 format!("{{ {} }}", entries.join(", "))
             }
@@ -232,7 +253,7 @@ impl GcObject {
 
     pub fn to_json_string(&self, gc: &super::gc::Gc) -> String {
         match &self.kind {
-            ObjKind::String(s) => format!("\"{}\"", s),
+            ObjKind::String(s) => escape_json_string(s),
             ObjKind::Array(items) => {
                 let entries: Vec<String> = items.iter().map(|v| v.to_json_string(gc)).collect();
                 format!("[{}]", entries.join(", "))
@@ -240,7 +261,7 @@ impl GcObject {
             ObjKind::Object(map) => {
                 let entries: Vec<String> = map
                     .iter()
-                    .map(|(k, v)| format!("\"{}\": {}", k, v.to_json_string(gc)))
+                    .map(|(k, v)| format!("{}: {}", escape_json_string(k), v.to_json_string(gc)))
                     .collect();
                 format!("{{ {} }}", entries.join(", "))
             }


### PR DESCRIPTION
## Summary
- Add escape_json_string() helper that properly escapes backslash, quotes, newlines, tabs, and control chars
- Fix to_json_string() in both interpreter Value and VM GcObject
- Fix object key escaping in VM display() method
- Replace manual ask keyword body escaping with serde_json::json!() macro

## Test plan
- [x] cargo test — 950 tests pass

Roadmap items: 7A.1 + 7A.5