### PR TITLE
fix: eliminate all 16 compiler warnings

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -32,6 +32,7 @@ fn escape_json_string(s: &str) -> String {
 
 /// Thread-safe channel inner type
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct ChannelInner {
     pub tx: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<Value>>>,
     pub rx: std::sync::Mutex<Option<std::sync::mpsc::Receiver<Value>>>,
@@ -380,6 +381,7 @@ pub enum DebugAction {
 
 /// Debug frame for stack trace reporting
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct DebugFrame {
     pub name: String,
     pub line: usize,
@@ -959,9 +961,9 @@ impl Interpreter {
                     if let Stmt::FnDef {
                         name: method_name,
                         params,
-                        return_type,
+                        return_type: _,
                         body,
-                        is_async,
+                        is_async: _,
                         ..
                     } = &method_spanned.stmt
                     {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -65,6 +65,7 @@ pub struct DetailedDep {
     pub path: String,
 }
 
+#[allow(dead_code)]
 impl DependencySpec {
     pub fn is_git(&self) -> bool {
         match self {
@@ -153,6 +154,7 @@ pub struct LockedPackage {
     pub checksum: String,
 }
 
+#[allow(dead_code)]
 impl Lockfile {
     pub fn load() -> Option<Self> {
         let path = Path::new("forge.lock");

--- a/src/stdlib/npc.rs
+++ b/src/stdlib/npc.rs
@@ -309,10 +309,6 @@ pub fn call(name: &str, args: Vec<Value>) -> Result<Value, String> {
     }
 }
 
-pub fn call_vm(name: &str, args: Vec<Value>) -> Result<Value, String> {
-    call(name, args)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/stdlib/ws.rs
+++ b/src/stdlib/ws.rs
@@ -28,6 +28,7 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
+#[allow(dead_code)]
 struct WsConnection {
     write: Arc<Mutex<WsSink>>,
     read: Arc<Mutex<WsStream>>,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -9,6 +9,7 @@ use crate::parser::ast::*;
 use std::collections::HashMap;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct TypeWarning {
     pub message: String,
     pub line: usize,
@@ -176,6 +177,7 @@ fn types_compatible(expected: &InferredType, actual: &InferredType) -> bool {
     false
 }
 
+#[allow(dead_code)]
 impl TypeChecker {
     pub fn new() -> Self {
         Self {
@@ -733,22 +735,6 @@ impl TypeChecker {
                 InferredType::Unknown
             }
         }
-    }
-}
-
-fn type_ann_to_string(ann: &TypeAnn) -> String {
-    match ann {
-        TypeAnn::Simple(name) => name.clone(),
-        TypeAnn::Array(inner) => format!("[{}]", type_ann_to_string(inner)),
-        TypeAnn::Generic(name, args) => {
-            let arg_strs: Vec<String> = args.iter().map(type_ann_to_string).collect();
-            format!("{}<{}>", name, arg_strs.join(", "))
-        }
-        TypeAnn::Function(params, ret) => {
-            let param_strs: Vec<String> = params.iter().map(type_ann_to_string).collect();
-            format!("({}) -> {}", param_strs.join(", "), type_ann_to_string(ret))
-        }
-        TypeAnn::Optional(inner) => format!("?{}", type_ann_to_string(inner)),
     }
 }
 

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -58,4 +58,5 @@ impl CallFrame {
 pub const MAX_FRAMES: usize = 256;
 
 /// Maximum register count across all frames.
+#[allow(dead_code)]
 pub const MAX_REGISTERS: usize = MAX_FRAMES * 256;

--- a/src/vm/jit/runtime.rs
+++ b/src/vm/jit/runtime.rs
@@ -96,7 +96,7 @@ pub extern "C" fn rt_print(vm_ptr: *mut VM, encoded: u64) {
 
 /// Bridge: get a global variable by constant index
 pub extern "C" fn rt_get_global(vm_ptr: *mut VM, name_idx: u64) -> u64 {
-    let vm = unsafe { &mut *vm_ptr };
+    let _vm = unsafe { &mut *vm_ptr };
     let _ = name_idx;
     encode_null()
 }

--- a/src/vm/jit/type_analysis.rs
+++ b/src/vm/jit/type_analysis.rs
@@ -8,12 +8,14 @@ pub enum RegType {
     Unknown,
 }
 
+#[allow(dead_code)]
 impl RegType {
     pub fn is_numeric(&self) -> bool {
         matches!(self, RegType::Int | RegType::Float)
     }
 }
 
+#[allow(dead_code)]
 pub struct TypeInfo {
     pub reg_types: Vec<RegType>,
     pub has_unsupported_ops: bool,

--- a/src/vm/profiler.rs
+++ b/src/vm/profiler.rs
@@ -24,6 +24,7 @@ pub struct Profiler {
     enabled: bool,
 }
 
+#[allow(dead_code)]
 impl Profiler {
     pub fn new(enabled: bool) -> Self {
         Self {


### PR DESCRIPTION
## Summary
- Eliminates all 16 compiler warnings for a clean `cargo build` output
- Removes truly dead code: `npc::call_vm` wrapper, `typechecker::type_ann_to_string`
- Prefixes unused destructure variables with `_`
- Adds `#[allow(dead_code)]` on infrastructure code kept for future use (package manager, JIT type analysis, profiler, typechecker, debug frames)

## Roadmap item
Phase 7B.1 — Eliminate all compiler warnings

## Test plan
- [x] `cargo build` produces zero warnings
- [x] `cargo test` — 950 tests pass