### PR TITLE
perf: unify HTTP async runtime

### DIFF
--- a/src/stdlib/http.rs
+++ b/src/stdlib/http.rs
@@ -400,17 +400,19 @@ fn do_crawl(args: &[Value]) -> Result<Value, String> {
 
 fn run_async<F, T>(future: F) -> Result<T, String>
 where
-    F: std::future::Future<Output = Result<T, String>> + Send + 'static,
-    T: Send + 'static,
+    F: std::future::Future<Output = Result<T, String>>,
 {
-    // Always create a fresh runtime on a separate thread to avoid nesting issues
-    let handle = std::thread::spawn(move || {
-        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("runtime error: {}", e))?;
-        rt.block_on(future)
-    });
-    handle
-        .join()
-        .map_err(|_| "async execution panicked".to_string())?
+    // Reuse the current Tokio runtime if available (VM/interpreter async context),
+    // otherwise fall back to a thread-local runtime to avoid creating one per call.
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| handle.block_on(future))
+    } else {
+        thread_local! {
+            static RT: tokio::runtime::Runtime = tokio::runtime::Runtime::new()
+                .expect("BUG: failed to create fallback tokio runtime");
+        }
+        RT.with(|rt| rt.block_on(future))
+    }
 }
 
 fn extract_between(html: &str, start_tag: &str, end_tag: &str) -> Option<String> {


### PR DESCRIPTION
## Summary
- Replaces per-call thread+runtime creation in http.rs with Handle::try_current() + block_in_place
- Falls back to thread-local runtime when no Tokio context exists
- Matches the pg/mysql module pattern already in use
- Eliminates Tokio runtime allocation on every HTTP request

## Roadmap item
Phase 7C.1 — Unify async runtime

## Test plan
- [x] cargo build clean
- [x] cargo test 950 tests pass
- [x] Relaxed Send + static bounds (future no longer spawned on separate thread)