### PR TITLE
fix: string .len returns char count, not byte count

### DIFF
--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1466,7 +1466,8 @@ impl VM {
                                     }
                                     ObjKind::String(s) => match field.as_str() {
                                         "len" => {
-                                            direct_result = Some(Value::Int(s.len() as i64));
+                                            direct_result =
+                                                Some(Value::Int(s.chars().count() as i64));
                                             needs_alloc = None;
                                         }
                                         "upper" => {


### PR DESCRIPTION
## Summary
- VM GetField 'len' on strings used s.len() (bytes) instead of s.chars().count() (chars)
- Now matches the Len opcode and interpreter behavior
- Fixes incorrect length for multi-byte UTF-8 strings (emoji, CJK, etc.)

## Roadmap item
Phase 7C.2 — Fix string .len property inconsistency

## Test plan
- [x] cargo build clean
- [x] cargo test 950 tests pass