### PR TITLE
perf: variable-width VM frames

### DIFF
--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -26,6 +26,8 @@ pub struct CallFrame {
     pub ip: usize,
     /// Base index into the VM's register array for this frame's window
     pub base: usize,
+    /// Number of registers this frame uses (from chunk.max_registers)
+    pub size: usize,
     /// Active exception handlers for this frame, innermost last.
     pub handlers: Vec<ExceptionHandler>,
     /// Active timeout scopes for this frame, innermost last.
@@ -35,11 +37,12 @@ pub struct CallFrame {
 }
 
 impl CallFrame {
-    pub fn new(closure: GcRef, base: usize) -> Self {
+    pub fn new(closure: GcRef, base: usize, size: usize) -> Self {
         Self {
             closure,
             ip: 0,
             base,
+            size,
             handlers: Vec::new(),
             timeouts: Vec::new(),
             open_upvalues: HashMap::new(),

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -934,7 +934,9 @@ impl VM {
         };
         let closure_ref = self.gc.alloc(ObjKind::Closure(closure));
 
-        self.frames.push(CallFrame::new(closure_ref, 0));
+        let frame_size = (chunk.max_registers as usize).max(1);
+        self.ensure_registers(frame_size);
+        self.frames.push(CallFrame::new(closure_ref, 0, frame_size));
         self.run_until(0)
     }
 
@@ -948,12 +950,14 @@ impl VM {
             upvalues: Vec::new(),
         };
         let closure_ref = self.gc.alloc(ObjKind::Closure(closure));
-        let new_base = self.frames.last().map(|f| f.base + 256).unwrap_or(0);
+        let new_base = self.frames.last().map(|f| f.base + f.size).unwrap_or(0);
+        let frame_size = (chunk.max_registers as usize).max(1);
         if self.frames.len() >= MAX_FRAMES {
             return Err(VMError::new("stack overflow"));
         }
-        self.ensure_registers(new_base + 256);
-        self.frames.push(CallFrame::new(closure_ref, new_base));
+        self.ensure_registers(new_base + frame_size);
+        self.frames
+            .push(CallFrame::new(closure_ref, new_base, frame_size));
         let boundary = self.frames.len() - 1;
         self.run_until(boundary)
     }
@@ -1967,7 +1971,7 @@ impl VM {
 
             // GC check
             if self.gc.should_collect() {
-                let max_reg = self.frames.last().map(|f| f.base + 256).unwrap_or(256);
+                let max_reg = self.frames.last().map(|f| f.base + f.size).unwrap_or(0);
                 let scan_limit = max_reg.min(self.registers.len());
                 let mut roots = Vec::with_capacity(scan_limit / 4);
                 for r in &self.registers[..scan_limit] {
@@ -2106,11 +2110,12 @@ impl VM {
                         }
 
                         let arity = chunk.arity as usize;
-                        let new_base = self.frames.last().map(|f| f.base + 256).unwrap_or(0);
+                        let frame_size = (chunk.max_registers as usize).max(1);
+                        let new_base = self.frames.last().map(|f| f.base + f.size).unwrap_or(0);
                         if self.frames.len() >= MAX_FRAMES {
                             return Err(VMError::new("stack overflow"));
                         }
-                        self.ensure_registers(new_base + 256);
+                        self.ensure_registers(new_base + frame_size);
 
                         for (i, arg) in args.iter().enumerate() {
                             if i < arity {
@@ -2121,7 +2126,7 @@ impl VM {
                             self.registers[new_base + i] = Value::Null;
                         }
 
-                        self.frames.push(CallFrame::new(*r, new_base));
+                        self.frames.push(CallFrame::new(*r, new_base, frame_size));
                         let boundary = self.frames.len() - 1;
                         self.run_until(boundary)
                     }


### PR DESCRIPTION
## Summary
- Adds size field to CallFrame, computed from chunk.max_registers
- Replaces hardcoded 256-register frames with actual register usage
- A 3-arg function now uses ~5 registers instead of 256
- GC root scanning tightened to only scan live register range
- Reduces memory per frame by ~50x for typical functions

## Roadmap item
Phase 7C.3 — Variable-width VM frames

## Test plan
- [x] cargo build clean
- [x] cargo test 950 tests pass
- [x] All parity tests pass (interpreter/VM/JIT agree)