### PR TITLE
feat: add --allow-run permission flag

### DIFF
--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1371,9 +1371,11 @@ impl Interpreter {
                 std::process::exit(code);
             }
             "run_command" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 crate::stdlib::exec_module::call(args).map_err(|e| RuntimeError::new(&e))
             }
             "shell" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let cmd = match args.first() {
                     Some(Value::String(s)) => s.clone(),
                     _ => return Err(RuntimeError::new("shell() requires a command string")),
@@ -1400,6 +1402,7 @@ impl Interpreter {
                 Ok(Value::Object(result))
             }
             "sh" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let cmd = match args.first() {
                     Some(Value::String(s)) => s.clone(),
                     _ => return Err(RuntimeError::new("sh() requires a command string")),
@@ -1416,6 +1419,7 @@ impl Interpreter {
                 ))
             }
             "sh_lines" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let cmd = match args.first() {
                     Some(Value::String(s)) => s.clone(),
                     _ => return Err(RuntimeError::new("sh_lines() requires a command string")),
@@ -1434,6 +1438,7 @@ impl Interpreter {
                 Ok(Value::Array(lines))
             }
             "sh_json" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let cmd = match args.first() {
                     Some(Value::String(s)) => s.clone(),
                     _ => return Err(RuntimeError::new("sh_json() requires a command string")),
@@ -1449,6 +1454,7 @@ impl Interpreter {
                 Ok(crate::runtime::server::json_to_forge(json))
             }
             "sh_ok" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let cmd = match args.first() {
                     Some(Value::String(s)) => s.clone(),
                     _ => return Err(RuntimeError::new("sh_ok() requires a command string")),
@@ -1500,6 +1506,7 @@ impl Interpreter {
                 _ => Err(RuntimeError::new("lines() requires a string")),
             },
             "pipe_to" => {
+                crate::permissions::check_run_permission().map_err(|e| RuntimeError::new(&e))?;
                 let (input, cmd) = match (args.first(), args.get(1)) {
                     (Some(Value::String(data)), Some(Value::String(cmd))) => {
                         (data.clone(), cmd.clone())

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -544,6 +544,7 @@ fn triple_quoted_string() {
 
 #[test]
 fn run_command_works() {
+    crate::permissions::set_allow_run(true);
     let result = try_run_forge(
         r#"
         let r = run_command("echo hello")

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod lsp;
 mod manifest;
 mod native;
 mod package;
+mod permissions;
 mod parser;
 mod publish;
 mod repl;
@@ -93,6 +94,11 @@ struct Cli {
     /// Enforce type annotations as errors (gradual strict mode)
     #[arg(long = "strict")]
     strict: bool,
+
+    /// Allow shell execution (sh, shell, run_command, sh_lines, sh_json, sh_ok, pipe_to).
+    /// Without this flag, these builtins return a permission error.
+    #[arg(long = "allow-run")]
+    allow_run: bool,
 }
 
 #[derive(Subcommand)]
@@ -191,6 +197,11 @@ async fn main() {
     let use_vm = !cli.use_interp || cli.use_jit || cli.profile;
     let profile = cli.profile;
     let strict = cli.strict;
+    // REPL and -e are user-invoked contexts — always allow shell execution.
+    // For file execution (forge run), require explicit --allow-run.
+    let is_interactive = cli.eval_code.is_some()
+        || matches!(cli.command, Some(Command::Repl) | None);
+    permissions::set_allow_run(cli.allow_run || is_interactive);
 
     if let Some(code) = cli.eval_code {
         let code = code.replace(';', "\n");

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,0 +1,17 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ALLOW_RUN: AtomicBool = AtomicBool::new(false);
+
+/// Enable shell execution permission (called from CLI when --allow-run is set).
+pub fn set_allow_run(allowed: bool) {
+    ALLOW_RUN.store(allowed, Ordering::SeqCst);
+}
+
+/// Check if shell execution is allowed. Returns Ok(()) or an error message.
+pub fn check_run_permission() -> Result<(), String> {
+    if ALLOW_RUN.load(Ordering::SeqCst) {
+        Ok(())
+    } else {
+        Err("Shell execution denied. Use --allow-run to enable sh/shell/run_command.".to_string())
+    }
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -1352,6 +1352,7 @@ impl VM {
                 std::process::exit(code);
             }
             "run_command" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
                     .map(|v| match v {
@@ -1552,6 +1553,7 @@ impl VM {
                 Ok(self.convert_interp_value(&result))
             }
             "shell" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let cmd = self.get_string_arg(&args, 0)?;
                 let output = std::process::Command::new("/bin/sh")
                     .arg("-c")
@@ -1576,6 +1578,7 @@ impl VM {
                 Ok(Value::Obj(r))
             }
             "sh" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let cmd = self.get_string_arg(&args, 0)?;
                 let output = std::process::Command::new("/bin/sh")
                     .arg("-c")
@@ -1589,6 +1592,7 @@ impl VM {
                 ))
             }
             "sh_lines" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let cmd = self.get_string_arg(&args, 0)?;
                 let output = std::process::Command::new("/bin/sh")
                     .arg("-c")
@@ -1605,6 +1609,7 @@ impl VM {
                 Ok(Value::Obj(r))
             }
             "sh_json" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let cmd = self.get_string_arg(&args, 0)?;
                 let output = std::process::Command::new("/bin/sh")
                     .arg("-c")
@@ -1618,6 +1623,7 @@ impl VM {
                 Ok(self.convert_interp_value(&interp_val))
             }
             "sh_ok" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let cmd = self.get_string_arg(&args, 0)?;
                 let status = std::process::Command::new("/bin/sh")
                     .arg("-c")
@@ -1657,6 +1663,7 @@ impl VM {
                 Ok(Value::Obj(r))
             }
             "pipe_to" => {
+                crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let input = self.get_string_arg(&args, 0)?;
                 let cmd = self.get_string_arg(&args, 1)?;
                 use std::io::Write;


### PR DESCRIPTION
## Summary
- New --allow-run CLI flag gates shell execution builtins
- Affected: sh, shell, run_command, sh_lines, sh_json, sh_ok, pipe_to
- REPL and -e auto-enable (user-invoked contexts)
- which exempted (read-only PATH inspection)
- New src/permissions.rs with AtomicBool for thread-safe checks
- Gates in both interpreter/builtins.rs and vm/builtins.rs

## Roadmap item
Phase 7D.2 — Add --allow-run permission flag

## Test plan
- [x] cargo build clean
- [x] cargo test 950 tests pass
- [x] run_command test enables permission before running