### PR TITLE
feat: add os and path stdlib modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`os` stdlib module** — `hostname()`, `platform()`, `arch()`, `pid()`, `cpus()`, `homedir()` for runtime OS introspection. ([#59](https://github.com/humancto/forge-lang/pull/59))
+- **`path` stdlib module** — `join()`, `resolve()`, `relative()`, `is_absolute()`, `dirname()`, `basename()`, `extname()`, `separator` for cross-platform path manipulation. ([#59](https://github.com/humancto/forge-lang/pull/59))
+
 ### Changed
 
 - **Cranelift JIT is now an optional cargo feature** — enabled by default. Build without it via `cargo install forge-lang --no-default-features` for faster compile times and broader platform support. ([#41](https://github.com/humancto/forge-lang/pull/41))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ forge fmt                    # format code
 
 run, repl, version, fmt, test, new, build, install, publish, lsp, dap, learn, chat, doc, help, -e
 
-## Standard Library (18 modules, 238+ functions)
+## Standard Library (20 modules, 250+ functions)
 
 | Module   | Key Functions                                                                                                                                                    |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -84,6 +84,8 @@ run, repl, version, fmt, test, new, build, install, publish, lsp, dap, learn, ch
 | `csv`    | parse, stringify, read, write                                                                                                                                    |
 | `term`   | red/green/blue/yellow/bold/dim, table, hr, sparkline, bar, banner, box, gradient, success/error                                                                  |
 | `exec`   | run_command                                                                                                                                                      |
+| `os`     | hostname, platform, arch, pid, cpus, homedir                                                                                                                     |
+| `path`   | join, resolve, relative, is_absolute, dirname, basename, extname, separator                                                                                      |
 | `npc`    | name, first_name, last_name, email, username, phone, number, pick, bool, sentence, word, id, color, ip, url, company                                             |
 
 ## Core Builtins (beyond modules)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "dotenvy",
  "flate2",
  "futures-util",
+ "gethostname",
  "getrandom 0.2.17",
  "hex",
  "hmac",
@@ -983,6 +984,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -2446,16 +2457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,9 +2730,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ cranelift-frontend = { version = "0.129", optional = true }
 cranelift-jit = { version = "0.129", optional = true }
 cranelift-module = { version = "0.129", optional = true }
 cranelift-native = { version = "0.129", optional = true }
+gethostname = "1.1.0"
 
 [features]
 default = ["jit", "postgres", "mysql"]

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1353,6 +1353,12 @@ impl Interpreter {
             _ if name.starts_with("jwt.") => {
                 crate::stdlib::jwt::call(name, args).map_err(|e| RuntimeError::new(&e))
             }
+            _ if name.starts_with("os.") => {
+                crate::stdlib::os_module::call(name, args).map_err(|e| RuntimeError::new(&e))
+            }
+            _ if name.starts_with("path.") => {
+                crate::stdlib::path_module::call(name, args).map_err(|e| RuntimeError::new(&e))
+            }
             #[cfg(feature = "mysql")]
             _ if name.starts_with("mysql.") => {
                 crate::stdlib::mysql::call(name, args).map_err(|e| RuntimeError::new(&e))

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -525,6 +525,10 @@ impl Interpreter {
             .define("ws".to_string(), crate::stdlib::create_ws_module());
         self.env
             .define("jwt".to_string(), crate::stdlib::create_jwt_module());
+        self.env
+            .define("os".to_string(), crate::stdlib::create_os_module());
+        self.env
+            .define("path".to_string(), crate::stdlib::create_path_module());
         #[cfg(feature = "mysql")]
         self.env
             .define("mysql".to_string(), crate::stdlib::create_mysql_module());

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -13,6 +13,8 @@ pub mod math;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 pub mod npc;
+pub mod os_module;
+pub mod path_module;
 #[cfg(feature = "postgres")]
 pub mod pg;
 pub mod regex_module;
@@ -81,6 +83,12 @@ pub fn create_ws_module() -> Value {
 }
 pub fn create_jwt_module() -> Value {
     jwt::create_module()
+}
+pub fn create_os_module() -> Value {
+    os_module::create_module()
+}
+pub fn create_path_module() -> Value {
+    path_module::create_module()
 }
 #[cfg(feature = "mysql")]
 pub fn create_mysql_module() -> Value {

--- a/src/stdlib/os_module.rs
+++ b/src/stdlib/os_module.rs
@@ -1,0 +1,130 @@
+use crate::interpreter::Value;
+use indexmap::IndexMap;
+
+pub fn create_module() -> Value {
+    let mut m = IndexMap::new();
+    m.insert(
+        "hostname".to_string(),
+        Value::BuiltIn("os.hostname".to_string()),
+    );
+    m.insert(
+        "platform".to_string(),
+        Value::BuiltIn("os.platform".to_string()),
+    );
+    m.insert("arch".to_string(), Value::BuiltIn("os.arch".to_string()));
+    m.insert("pid".to_string(), Value::BuiltIn("os.pid".to_string()));
+    m.insert("cpus".to_string(), Value::BuiltIn("os.cpus".to_string()));
+    m.insert(
+        "homedir".to_string(),
+        Value::BuiltIn("os.homedir".to_string()),
+    );
+    Value::Object(m)
+}
+
+pub fn call(name: &str, _args: Vec<Value>) -> Result<Value, String> {
+    match name {
+        "os.hostname" => {
+            let hostname = gethostname::gethostname();
+            Ok(Value::String(hostname.to_string_lossy().into_owned()))
+        }
+        "os.platform" => {
+            let platform = match std::env::consts::OS {
+                "macos" => "macos",
+                "linux" => "linux",
+                "windows" => "windows",
+                "freebsd" => "freebsd",
+                "openbsd" => "openbsd",
+                "netbsd" => "netbsd",
+                other => other,
+            };
+            Ok(Value::String(platform.to_string()))
+        }
+        "os.arch" => Ok(Value::String(std::env::consts::ARCH.to_string())),
+        "os.pid" => Ok(Value::Int(std::process::id() as i64)),
+        "os.cpus" => {
+            let cpus = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1);
+            Ok(Value::Int(cpus as i64))
+        }
+        "os.homedir" => {
+            let home = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .unwrap_or_default();
+            if home.is_empty() {
+                Ok(Value::Null)
+            } else {
+                Ok(Value::String(home))
+            }
+        }
+        _ => Err(format!("unknown os function: {}", name)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hostname_returns_nonempty_string() {
+        let result = call("os.hostname", vec![]).unwrap();
+        if let Value::String(s) = result {
+            assert!(!s.is_empty());
+        } else {
+            panic!("expected string");
+        }
+    }
+
+    #[test]
+    fn platform_is_known() {
+        let result = call("os.platform", vec![]).unwrap();
+        if let Value::String(s) = result {
+            assert!(
+                ["macos", "linux", "windows", "freebsd", "openbsd", "netbsd"].contains(&s.as_str())
+                    || !s.is_empty()
+            );
+        } else {
+            panic!("expected string");
+        }
+    }
+
+    #[test]
+    fn arch_is_nonempty() {
+        let result = call("os.arch", vec![]).unwrap();
+        if let Value::String(s) = result {
+            assert!(!s.is_empty());
+        } else {
+            panic!("expected string");
+        }
+    }
+
+    #[test]
+    fn pid_is_positive() {
+        let result = call("os.pid", vec![]).unwrap();
+        if let Value::Int(n) = result {
+            assert!(n > 0);
+        } else {
+            panic!("expected int");
+        }
+    }
+
+    #[test]
+    fn cpus_is_at_least_one() {
+        let result = call("os.cpus", vec![]).unwrap();
+        if let Value::Int(n) = result {
+            assert!(n >= 1);
+        } else {
+            panic!("expected int");
+        }
+    }
+
+    #[test]
+    fn homedir_returns_string_or_null() {
+        let result = call("os.homedir", vec![]).unwrap();
+        match result {
+            Value::String(s) => assert!(!s.is_empty()),
+            Value::Null => {} // OK in CI environments
+            _ => panic!("expected string or null"),
+        }
+    }
+}

--- a/src/stdlib/path_module.rs
+++ b/src/stdlib/path_module.rs
@@ -1,0 +1,282 @@
+use crate::interpreter::Value;
+use indexmap::IndexMap;
+use std::path::{Path, PathBuf};
+
+pub fn create_module() -> Value {
+    let mut m = IndexMap::new();
+    m.insert("join".to_string(), Value::BuiltIn("path.join".to_string()));
+    m.insert(
+        "resolve".to_string(),
+        Value::BuiltIn("path.resolve".to_string()),
+    );
+    m.insert(
+        "relative".to_string(),
+        Value::BuiltIn("path.relative".to_string()),
+    );
+    m.insert(
+        "is_absolute".to_string(),
+        Value::BuiltIn("path.is_absolute".to_string()),
+    );
+    m.insert(
+        "dirname".to_string(),
+        Value::BuiltIn("path.dirname".to_string()),
+    );
+    m.insert(
+        "basename".to_string(),
+        Value::BuiltIn("path.basename".to_string()),
+    );
+    m.insert(
+        "extname".to_string(),
+        Value::BuiltIn("path.extname".to_string()),
+    );
+    m.insert(
+        "separator".to_string(),
+        Value::String(std::path::MAIN_SEPARATOR_STR.to_string()),
+    );
+    Value::Object(m)
+}
+
+fn require_string(args: &[Value], idx: usize, fn_name: &str) -> Result<String, String> {
+    match args.get(idx) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(other) => Err(format!(
+            "{}() argument {} must be a string, got {}",
+            fn_name,
+            idx + 1,
+            other.type_name()
+        )),
+        None => Err(format!(
+            "{}() requires at least {} argument(s)",
+            fn_name,
+            idx + 1
+        )),
+    }
+}
+
+pub fn call(name: &str, args: Vec<Value>) -> Result<Value, String> {
+    match name {
+        "path.join" => {
+            if args.is_empty() {
+                return Ok(Value::String(String::new()));
+            }
+            let first = require_string(&args, 0, "path.join")?;
+            let mut buf = PathBuf::from(first);
+            for (i, arg) in args.iter().enumerate().skip(1) {
+                match arg {
+                    Value::String(s) => buf.push(s),
+                    _ => {
+                        return Err(format!(
+                            "path.join() argument {} must be a string, got {}",
+                            i + 1,
+                            arg.type_name()
+                        ))
+                    }
+                }
+            }
+            Ok(Value::String(buf.to_string_lossy().into_owned()))
+        }
+        "path.resolve" => {
+            let p = require_string(&args, 0, "path.resolve")?;
+            match std::fs::canonicalize(&p) {
+                Ok(abs) => Ok(Value::String(abs.to_string_lossy().into_owned())),
+                Err(e) => Err(format!("path.resolve('{}') failed: {}", p, e)),
+            }
+        }
+        "path.relative" => {
+            let from = require_string(&args, 0, "path.relative")?;
+            let to = require_string(&args, 1, "path.relative")?;
+
+            let from_abs = std::fs::canonicalize(&from)
+                .map_err(|e| format!("path.relative(): cannot resolve '{}': {}", from, e))?;
+            let to_abs = std::fs::canonicalize(&to)
+                .map_err(|e| format!("path.relative(): cannot resolve '{}': {}", to, e))?;
+
+            let from_components: Vec<_> = from_abs.components().collect();
+            let to_components: Vec<_> = to_abs.components().collect();
+
+            let common_len = from_components
+                .iter()
+                .zip(to_components.iter())
+                .take_while(|(a, b)| a == b)
+                .count();
+
+            let mut rel = PathBuf::new();
+            for _ in common_len..from_components.len() {
+                rel.push("..");
+            }
+            for component in &to_components[common_len..] {
+                rel.push(component);
+            }
+
+            if rel.as_os_str().is_empty() {
+                Ok(Value::String(".".to_string()))
+            } else {
+                Ok(Value::String(rel.to_string_lossy().into_owned()))
+            }
+        }
+        "path.is_absolute" => {
+            let p = require_string(&args, 0, "path.is_absolute")?;
+            Ok(Value::Bool(Path::new(&p).is_absolute()))
+        }
+        "path.dirname" => {
+            let p = require_string(&args, 0, "path.dirname")?;
+            let result = Path::new(&p)
+                .parent()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            Ok(Value::String(result))
+        }
+        "path.basename" => {
+            let p = require_string(&args, 0, "path.basename")?;
+            let result = Path::new(&p)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            Ok(Value::String(result))
+        }
+        "path.extname" => {
+            let p = require_string(&args, 0, "path.extname")?;
+            let result = Path::new(&p)
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+            Ok(Value::String(result))
+        }
+        _ => Err(format!("unknown path function: {}", name)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_two_segments() {
+        let result = call(
+            "path.join",
+            vec![Value::String("a".into()), Value::String("b".into())],
+        )
+        .unwrap();
+        assert_eq!(result, Value::String("a/b".into()));
+    }
+
+    #[test]
+    fn join_three_segments() {
+        let result = call(
+            "path.join",
+            vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+                Value::String("c.txt".into()),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::String("a/b/c.txt".into()));
+    }
+
+    #[test]
+    fn join_empty_args() {
+        let result = call("path.join", vec![]).unwrap();
+        assert_eq!(result, Value::String(String::new()));
+    }
+
+    #[test]
+    fn join_rejects_non_string() {
+        let result = call("path.join", vec![Value::String("a".into()), Value::Int(42)]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_absolute_detects_absolute() {
+        let result = call("path.is_absolute", vec![Value::String("/usr/bin".into())]).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn is_absolute_detects_relative() {
+        let result = call(
+            "path.is_absolute",
+            vec![Value::String("src/main.rs".into())],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[test]
+    fn dirname_of_file_path() {
+        let result = call("path.dirname", vec![Value::String("/usr/bin/env".into())]).unwrap();
+        assert_eq!(result, Value::String("/usr/bin".into()));
+    }
+
+    #[test]
+    fn dirname_of_empty() {
+        let result = call("path.dirname", vec![Value::String(String::new())]).unwrap();
+        assert_eq!(result, Value::String(String::new()));
+    }
+
+    #[test]
+    fn basename_of_file_path() {
+        let result = call("path.basename", vec![Value::String("/usr/bin/env".into())]).unwrap();
+        assert_eq!(result, Value::String("env".into()));
+    }
+
+    #[test]
+    fn basename_of_empty() {
+        let result = call("path.basename", vec![Value::String(String::new())]).unwrap();
+        assert_eq!(result, Value::String(String::new()));
+    }
+
+    #[test]
+    fn extname_of_file() {
+        let result = call("path.extname", vec![Value::String("file.txt".into())]).unwrap();
+        assert_eq!(result, Value::String(".txt".into()));
+    }
+
+    #[test]
+    fn extname_no_extension() {
+        let result = call("path.extname", vec![Value::String("Makefile".into())]).unwrap();
+        assert_eq!(result, Value::String(String::new()));
+    }
+
+    #[test]
+    fn resolve_existing_path() {
+        let result = call("path.resolve", vec![Value::String(".".into())]).unwrap();
+        if let Value::String(s) = result {
+            assert!(Path::new(&s).is_absolute());
+        } else {
+            panic!("expected string");
+        }
+    }
+
+    #[test]
+    fn resolve_nonexistent_errors() {
+        let result = call(
+            "path.resolve",
+            vec![Value::String("/nonexistent_path_xyz_123".into())],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn relative_same_dir() {
+        let result = call(
+            "path.relative",
+            vec![Value::String(".".into()), Value::String(".".into())],
+        )
+        .unwrap();
+        assert_eq!(result, Value::String(".".into()));
+    }
+
+    #[test]
+    fn separator_is_correct() {
+        let module = create_module();
+        if let Value::Object(m) = module {
+            assert_eq!(
+                m.get("separator"),
+                Some(&Value::String(std::path::MAIN_SEPARATOR_STR.to_string()))
+            );
+        } else {
+            panic!("expected object");
+        }
+    }
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -1371,6 +1371,45 @@ impl VM {
                     crate::stdlib::exec_module::call(interp_args).map_err(|e| VMError::new(&e))?;
                 Ok(self.convert_interp_value(&result))
             }
+            n if n.starts_with("os.") => {
+                let interp_args: Vec<crate::interpreter::Value> = args
+                    .iter()
+                    .map(|v| match v {
+                        Value::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                                crate::interpreter::Value::String(s)
+                            } else {
+                                crate::interpreter::Value::Null
+                            }
+                        }
+                        _ => crate::interpreter::Value::Null,
+                    })
+                    .collect();
+                let result =
+                    crate::stdlib::os_module::call(n, interp_args).map_err(|e| VMError::new(&e))?;
+                Ok(self.convert_interp_value(&result))
+            }
+            n if n.starts_with("path.") => {
+                let interp_args: Vec<crate::interpreter::Value> = args
+                    .iter()
+                    .map(|v| match v {
+                        Value::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                                crate::interpreter::Value::String(s)
+                            } else {
+                                crate::interpreter::Value::Null
+                            }
+                        }
+                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        Value::Float(n) => crate::interpreter::Value::Float(*n),
+                        Value::Bool(b) => crate::interpreter::Value::Bool(*b),
+                        _ => crate::interpreter::Value::Null,
+                    })
+                    .collect();
+                let result = crate::stdlib::path_module::call(n, interp_args)
+                    .map_err(|e| VMError::new(&e))?;
+                Ok(self.convert_interp_value(&result))
+            }
             n if n.starts_with("env.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1492,7 +1492,8 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
         Stmt::Import { path, names } => {
             let builtin_modules = [
                 "math", "fs", "io", "crypto", "db", "pg", "env", "json", "regex", "log", "term",
-                "http", "csv", "exec", "time", "url", "toml", "npc", "ws", "jwt", "mysql",
+                "http", "csv", "exec", "time", "url", "toml", "npc", "ws", "jwt", "mysql", "os",
+                "path",
             ];
             if builtin_modules.contains(&path.as_str()) {
                 return Ok(());

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -759,6 +759,43 @@ impl VM {
                 .insert("mysql".to_string(), Value::Obj(mysql_ref));
         }
 
+        // os module
+        let mut os_map = IndexMap::new();
+        for name in &["hostname", "platform", "arch", "pid", "cpus", "homedir"] {
+            let full = format!("os.{}", name);
+            let nr = self
+                .gc
+                .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
+            os_map.insert(name.to_string(), Value::Obj(nr));
+        }
+        let os_ref = self.gc.alloc(ObjKind::Object(os_map));
+        self.globals.insert("os".to_string(), Value::Obj(os_ref));
+
+        // path module
+        let mut path_map = IndexMap::new();
+        for name in &[
+            "join",
+            "resolve",
+            "relative",
+            "is_absolute",
+            "dirname",
+            "basename",
+            "extname",
+        ] {
+            let full = format!("path.{}", name);
+            let nr = self
+                .gc
+                .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
+            path_map.insert(name.to_string(), Value::Obj(nr));
+        }
+        path_map.insert(
+            "separator".to_string(),
+            self.alloc_string(std::path::MAIN_SEPARATOR_STR),
+        );
+        let path_ref = self.gc.alloc(ObjKind::Object(path_map));
+        self.globals
+            .insert("path".to_string(), Value::Obj(path_ref));
+
         // Option prelude
         let mut none_obj = IndexMap::new();
         none_obj.insert("__type__".to_string(), self.alloc_string("Option"));

--- a/tests/parity/supported/os_path_modules.fg
+++ b/tests/parity/supported/os_path_modules.fg
@@ -1,0 +1,4 @@
+// expect: [src/main.rs, /, main.rs, .rs, src, false]
+
+let p = path.join("src", "main.rs")
+[p, path.separator, path.basename(p), path.extname(p), path.dirname(p), path.is_absolute(p)]


### PR DESCRIPTION
## Summary

- Adds `os` module: `hostname()`, `platform()`, `arch()`, `pid()`, `cpus()`, `homedir()`
- Adds `path` module: `join()`, `resolve()`, `relative()`, `is_absolute()`, `dirname()`, `basename()`, `extname()`, `separator`
- Registered in interpreter, VM compiler, VM machine globals, and VM builtins
- Added `gethostname` crate for cross-platform hostname support
- Parity test fixture confirms identical output across interpreter, VM, bytecode round-trip, and JIT

Roadmap item: 7E.2

## Test plan

- [x] All 972 cargo tests pass
- [x] Parity fixture `tests/parity/supported/os_path_modules.fg` passes across all backends
- [x] Manual verification of all functions via `forge -e` in both VM and interpreter modes
- [x] Examples still run (`forge run examples/hello.fg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)