### PR TITLE
feat: parse generic type parameters on functions and structs

### DIFF
--- a/.planning/parse-generics.plan.md
+++ b/.planning/parse-generics.plan.md
@@ -1,0 +1,102 @@
+# Plan: 8B.1 — Parse generic type parameters
+
+## Goal
+
+Parse generic type parameters on function and struct definitions: `fn map<T, U>(...)` and `struct Pair<T> { ... }`. Store them in the AST. No type checking of generics yet (that's 8B.2).
+
+## Current behavior
+
+```forge
+fn map<T, U>(arr: [T], f: fn(T) -> U) -> [U] { ... }
+// Parse error: unexpected '<'
+```
+
+## Desired behavior
+
+```forge
+fn map<T, U>(arr: [T], f: fn(T) -> U) -> [U] { ... }
+// Parses successfully, type_params = ["T", "U"] stored in AST
+```
+
+## Approach
+
+### 1. Add `type_params` to AST nodes
+
+Add `type_params: Vec<String>` to:
+
+- `Stmt::FnDef` — generic functions
+- `Stmt::StructDef` — generic structs
+
+### 2. Parse `<T, U>` after names
+
+In `parse_fn_def`, after `let name = self.expect_ident()?;`:
+
+```
+let type_params = self.parse_type_params()?;
+```
+
+Same in `parse_struct_def`, after `let name = self.expect_ident()?;`.
+
+### 3. `parse_type_params` helper
+
+```rust
+fn parse_type_params(&mut self) -> Result<Vec<String>, ParseError> {
+    if !self.check(&Token::Lt) { return Ok(vec![]); }
+    self.advance(); // consume <
+    let mut params = Vec::new();
+    loop {
+        params.push(self.expect_ident()?);
+        if self.check(&Token::Comma) {
+            self.advance();
+        } else {
+            break;
+        }
+    }
+    self.expect(Token::Gt)?;
+    Ok(params)
+}
+```
+
+### 4. Update all AST consumers
+
+Every place that destructures `Stmt::FnDef` or `Stmt::StructDef` needs to handle the new field. Add `type_params: _` or use `..` to ignore it where appropriate.
+
+Key consumers:
+
+- `typechecker.rs` — `collect_definitions`, `check_stmt`, `infer_all_return_types`
+- `interpreter/mod.rs` — function/struct handling
+- `vm/compiler.rs` — function compilation
+- `lsp/mod.rs` — go-to-definition
+- Any other files that match on FnDef/StructDef
+
+### 5. TypeAnn already handles generic usage
+
+`TypeAnn::Generic(String, Vec<TypeAnn>)` already exists for type positions like `Result<Int, String>`. Type parameters like `T` in param types are already parsed as `TypeAnn::Simple("T")`. No changes needed to type annotation parsing.
+
+## Edge cases
+
+- Empty type params `fn f<>()` → parse error (require at least one)
+- `<` ambiguity: only parse type params right after an identifier in fn/struct position — no ambiguity with comparison since `<` can't follow a bare ident in these contexts
+- Existing code without generics: `type_params` is empty vec, no behavior change
+
+## Files to touch
+
+1. **`src/parser/ast.rs`** — add `type_params: Vec<String>` to FnDef and StructDef
+2. **`src/parser/parser.rs`** — add `parse_type_params()`, call it in `parse_fn_def` and `parse_struct_def`
+3. **`src/typechecker.rs`** — update destructure patterns for FnDef/StructDef (ignore type_params for now)
+4. **`src/interpreter/mod.rs`** — update destructure patterns
+5. **`src/vm/compiler.rs`** — update destructure patterns
+6. **`src/lsp/mod.rs`** — update destructure patterns
+7. **Other files** — any that match on FnDef/StructDef
+
+## Test strategy
+
+- Parse `fn f<T>(x: T) -> T { return x }` successfully
+- Parse `struct Pair<T> { first: T, second: T }` successfully
+- Parse `fn f<T, U>(x: T, y: U) -> T { return x }` (multiple params)
+- Existing functions without generics still parse
+- `type_params` is empty for non-generic functions
+
+## Rollback
+
+Revert all file changes (AST + parser + consumer updates).

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -861,7 +861,7 @@ impl Interpreter {
                 Ok(Signal::None)
             }
 
-            Stmt::StructDef { name, fields } => {
+            Stmt::StructDef { name, fields, .. } => {
                 self.env
                     .define(name.clone(), Value::BuiltIn(format!("struct:{}", name)));
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1216,6 +1216,7 @@ fn hover_from_stmt(stmt: &Stmt, name: &str) -> Option<String> {
         Stmt::StructDef {
             name: struct_name,
             fields,
+            ..
         } => {
             if struct_name == name {
                 let fields_str = fields

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -44,6 +44,7 @@ pub enum Stmt {
     },
     FnDef {
         name: String,
+        type_params: Vec<String>,
         params: Vec<Param>,
         return_type: Option<TypeAnn>,
         body: Vec<SpannedStmt>,
@@ -56,6 +57,7 @@ pub enum Stmt {
     },
     StructDef {
         name: String,
+        type_params: Vec<String>,
         fields: Vec<FieldDef>,
     },
     Return(Option<Expr>),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -822,6 +822,24 @@ impl Parser {
         })
     }
 
+    fn parse_type_params(&mut self) -> Result<Vec<String>, ParseError> {
+        if !self.check(&Token::Lt) {
+            return Ok(vec![]);
+        }
+        self.advance(); // consume <
+        let mut params = Vec::new();
+        loop {
+            params.push(self.expect_ident()?);
+            if self.check(&Token::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        self.expect(Token::Gt)?;
+        Ok(params)
+    }
+
     fn parse_fn_def(&mut self, decorators: Vec<Decorator>) -> Result<Stmt, ParseError> {
         let is_async = if self.check(&Token::Async) || self.check(&Token::ForgeKw) {
             self.advance();
@@ -839,6 +857,7 @@ impl Parser {
             return Err(self.error("expected 'fn' or 'define'"));
         }
         let name = self.expect_ident()?;
+        let type_params = self.parse_type_params()?;
 
         self.expect(Token::LParen)?;
         let params = self.parse_params()?;
@@ -855,6 +874,7 @@ impl Parser {
 
         Ok(Stmt::FnDef {
             name,
+            type_params,
             params,
             return_type,
             body,
@@ -873,6 +893,7 @@ impl Parser {
             return Err(self.error("expected 'struct' or 'thing'"));
         }
         let name = self.expect_ident()?;
+        let type_params = self.parse_type_params()?;
 
         self.expect(Token::LBrace)?;
         self.skip_newlines();
@@ -917,7 +938,11 @@ impl Parser {
         }
 
         self.expect(Token::RBrace)?;
-        Ok(Stmt::StructDef { name, fields })
+        Ok(Stmt::StructDef {
+            name,
+            type_params,
+            fields,
+        })
     }
 
     fn parse_return(&mut self) -> Result<Stmt, ParseError> {
@@ -2311,6 +2336,80 @@ mod tests {
                 assert_eq!(variants.len(), 2);
             }
             other => panic!("expected type definition, got {:?}", other),
+        }
+    }
+
+    // ========== 8B.1: Generic Type Parameters ==========
+
+    #[test]
+    fn parse_generic_function_single_param() {
+        let program = parse_program("fn identity<T>(x: T) -> T { return x }");
+        match &program.statements[0].stmt {
+            Stmt::FnDef {
+                name,
+                type_params,
+                params,
+                ..
+            } => {
+                assert_eq!(name, "identity");
+                assert_eq!(type_params, &vec!["T".to_string()]);
+                assert_eq!(params.len(), 1);
+            }
+            other => panic!("expected FnDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_generic_function_multiple_params() {
+        let program = parse_program("fn map<T, U>(arr: [T], b: U) -> [U] { return arr }");
+        match &program.statements[0].stmt {
+            Stmt::FnDef {
+                name, type_params, ..
+            } => {
+                assert_eq!(name, "map");
+                assert_eq!(type_params, &vec!["T".to_string(), "U".to_string()]);
+            }
+            other => panic!("expected FnDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_non_generic_function_has_empty_type_params() {
+        let program = parse_program("fn add(a: Int, b: Int) { return a + b }");
+        match &program.statements[0].stmt {
+            Stmt::FnDef { type_params, .. } => {
+                assert!(type_params.is_empty());
+            }
+            other => panic!("expected FnDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_generic_struct() {
+        let program = parse_program("struct Pair<T> {\n  first: T\n  second: T\n}");
+        match &program.statements[0].stmt {
+            Stmt::StructDef {
+                name,
+                type_params,
+                fields,
+                ..
+            } => {
+                assert_eq!(name, "Pair");
+                assert_eq!(type_params, &vec!["T".to_string()]);
+                assert_eq!(fields.len(), 2);
+            }
+            other => panic!("expected StructDef, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_non_generic_struct_has_empty_type_params() {
+        let program = parse_program("struct Point {\n  x: Int\n  y: Int\n}");
+        match &program.statements[0].stmt {
+            Stmt::StructDef { type_params, .. } => {
+                assert!(type_params.is_empty());
+            }
+            other => panic!("expected StructDef, got {:?}", other),
         }
     }
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -493,7 +493,7 @@ impl TypeChecker {
                     .collect();
                 self.interfaces.insert(name.clone(), method_sigs);
             }
-            Stmt::StructDef { name, fields } => {
+            Stmt::StructDef { name, fields, .. } => {
                 let field_names: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
                 self.structs.insert(name.clone(), field_names);
             }

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1001,7 +1001,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
         Stmt::DecoratorStmt(_) => Ok(()),
 
-        Stmt::StructDef { name, fields } => compile_hidden_stmt(
+        Stmt::StructDef { name, fields, .. } => compile_hidden_stmt(
             c,
             "__forge_register_struct",
             vec![


### PR DESCRIPTION
## Summary

- Adds type_params field to FnDef and StructDef AST nodes (roadmap item 8B.1)
- Parses `<T, U>` syntax after function and struct names
- Non-generic definitions get empty type_params vec (no behavior change)
- All consumer sites updated with `.." patterns

## Test plan

- [x] 5 new parser tests for generic syntax
- [x] All 1006 cargo tests pass
- [x] cargo build clean