### PR TITLE
feat: generic struct definitions with typed fields

### DIFF
--- a/.planning/generic-structs.plan.md
+++ b/.planning/generic-structs.plan.md
@@ -1,0 +1,60 @@
+# Plan: 8B.3 — Generic struct definitions
+
+## Goal
+
+Make the type checker aware of generic struct type parameters so that `struct Pair<T> { first: T, second: T }` has its fields correctly typed when the struct is instantiated.
+
+## Current state
+
+Parser already handles `struct Pair<T> { first: T, second: T }` (8B.1). The typechecker stores struct field names but not their types or type params. Constructor calls are not type-checked against struct field types.
+
+## Approach
+
+### 1. Store struct type params and field types
+
+Update `self.structs` from `HashMap<String, Vec<String>>` (field names only) to `HashMap<String, StructInfo>` where:
+
+```rust
+struct StructInfo {
+    type_params: Vec<String>,
+    fields: Vec<(String, InferredType)>,
+}
+```
+
+### 2. Update collect_definitions for StructDef
+
+Store both field names and their types, plus the struct's type params.
+
+### 3. Update all struct field access sites
+
+The `structs` map is used in:
+
+- `collect_definitions` (stores field names)
+- `check_interface_satisfaction` (checks field/method names)
+- Possibly `infer_expr` for constructor calls
+
+Update these to work with the new `StructInfo` type.
+
+### 4. Constructor type checking (stretch)
+
+When a struct is constructed like `Pair(1, 2)`, resolve `T = Int` from the arguments and validate field types. This may already work through the function call path if constructors are registered as functions.
+
+## Edge cases
+
+- Non-generic structs: `type_params` is empty, no resolution needed
+- Generic struct with unresolved params: fields stay as `Named("T")`
+- Struct field access via dot notation: not checked by current typechecker (out of scope)
+
+## Files to touch
+
+1. **`src/typechecker.rs`** — add StructInfo, update collect_definitions, update check_interface_satisfaction
+
+## Test strategy
+
+- Generic struct parses and stores type params
+- Non-generic struct still works
+- check_interface_satisfaction still works with new StructInfo
+
+## Rollback
+
+Revert the single file change.

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -41,7 +41,7 @@ pub struct TypeChecker {
     functions: HashMap<String, FnSignature>,
     type_defs: HashMap<String, Vec<String>>,
     interfaces: HashMap<String, Vec<InterfaceMethod>>,
-    structs: HashMap<String, Vec<String>>,
+    structs: HashMap<String, StructInfo>,
     variables: HashMap<String, InferredType>,
     current_fn_return: Option<InferredType>,
     current_line: usize,
@@ -55,6 +55,12 @@ struct FnSignature {
     params: Vec<(String, Option<InferredType>)>,
     param_count: usize,
     return_type: Option<InferredType>,
+}
+
+#[derive(Debug, Clone)]
+struct StructInfo {
+    type_params: Vec<String>,
+    fields: Vec<(String, InferredType)>,
 }
 
 #[derive(Debug, Clone)]
@@ -496,9 +502,23 @@ impl TypeChecker {
                     .collect();
                 self.interfaces.insert(name.clone(), method_sigs);
             }
-            Stmt::StructDef { name, fields, .. } => {
-                let field_names: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
-                self.structs.insert(name.clone(), field_names);
+            Stmt::StructDef {
+                name,
+                type_params,
+                fields,
+                ..
+            } => {
+                let field_info: Vec<(String, InferredType)> = fields
+                    .iter()
+                    .map(|f| (f.name.clone(), type_ann_to_inferred(&f.type_ann)))
+                    .collect();
+                self.structs.insert(
+                    name.clone(),
+                    StructInfo {
+                        type_params: type_params.clone(),
+                        fields: field_info,
+                    },
+                );
             }
             Stmt::ImplBlock {
                 type_name, methods, ..
@@ -545,8 +565,8 @@ impl TypeChecker {
     }
 
     fn check_interface_satisfaction(&mut self, struct_name: &str, interface_name: &str) {
-        let struct_fields = match self.structs.get(struct_name) {
-            Some(f) => f.clone(),
+        let struct_info = match self.structs.get(struct_name) {
+            Some(info) => info.clone(),
             None => return,
         };
         let methods = match self.interfaces.get(interface_name) {
@@ -555,7 +575,10 @@ impl TypeChecker {
         };
 
         for method in &methods {
-            let has_field = struct_fields.iter().any(|f| *f == method.name);
+            let has_field = struct_info
+                .fields
+                .iter()
+                .any(|(name, _)| *name == method.name);
             let has_fn = self
                 .functions
                 .get(&format!("{}_{}", struct_name, method.name))
@@ -1972,6 +1995,31 @@ mod tests {
         // Non-generic function behavior unchanged
         let w =
             warnings_for("fn add(a: Int, b: Int) -> Int { return a + b }\nlet y: Int = add(1, 2)");
+        assert!(w.is_empty());
+    }
+
+    // ========== 8B.3: Generic Struct Definitions ==========
+
+    #[test]
+    fn generic_struct_stores_type_params() {
+        // Generic struct should parse and type-check without errors
+        let w = warnings_for("struct Pair<T> {\n  first: T\n  second: T\n}");
+        assert!(
+            w.is_empty(),
+            "generic struct def should not warn: {:?}",
+            w.iter().map(|w| &w.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn non_generic_struct_still_works() {
+        let w = warnings_for("struct Point {\n  x: Int\n  y: Int\n}");
+        assert!(w.is_empty());
+    }
+
+    #[test]
+    fn generic_struct_with_multiple_type_params() {
+        let w = warnings_for("struct Either<L, R> {\n  left: L\n  right: R\n}");
         assert!(w.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Store struct type params and field types in StructInfo (roadmap 8B.3)
- Upgrades structs map from field names only to full StructInfo with type_params and typed fields
- Updates check_interface_satisfaction for new structure

## Test plan

- [x] 3 new typechecker tests
- [x] All 1014 cargo tests pass