### PR TITLE
feat: add channel select builtin (9A.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`select(channels, timeout?)` builtin** — wait on multiple channels, returns `[index, value]` for the first ready channel. Optional timeout in ms. ([#69](https://github.com/humancto/forge-lang/pull/69))
+
 ## [0.8.0] - 2026-04-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ run, repl, version, fmt, test, new, build, install, publish, lsp, dap, learn, ch
 - Validation: assert, assert_eq, assert_ne, assert_throws, satisfies
 - GenZ Debug Kit: sus (inspect), bruh (panic), bet (assert), no_cap (assert_eq), ick (assert-false)
 - Execution: cook (profiling), yolo (fire-and-forget), ghost (silent exec), slay (benchmarking)
-- Concurrency: channel, send, receive, try_send, try_receive
+- Concurrency: channel, send, receive, try_send, try_receive, select
 
 ## Build & Test
 

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1295,6 +1295,53 @@ impl Interpreter {
                     None => Ok(Value::None),
                 }
             }
+            "select" => {
+                if args.is_empty() {
+                    return Err(RuntimeError::new("select() requires an array of channels"));
+                }
+                let channels: Vec<Arc<ChannelInner>> = match &args[0] {
+                    Value::Array(items) => {
+                        let mut chs = Vec::with_capacity(items.len());
+                        for item in items {
+                            match item {
+                                Value::Channel(c) => chs.push(c.clone()),
+                                _ => {
+                                    return Err(RuntimeError::new(
+                                        "select() array must contain only channels",
+                                    ))
+                                }
+                            }
+                        }
+                        chs
+                    }
+                    _ => return Err(RuntimeError::new("select() requires an array of channels")),
+                };
+                if channels.is_empty() {
+                    return Err(RuntimeError::new("select() requires a non-empty array"));
+                }
+                let len = channels.len();
+                let mut offset = 0usize;
+                loop {
+                    let mut all_closed = true;
+                    for i in 0..len {
+                        let idx = (i + offset) % len;
+                        let rx_guard = channels[idx].rx.lock().map_err(|e| {
+                            RuntimeError::new(&format!("channel lock error: {}", e))
+                        })?;
+                        if let Some(ref rx) = *rx_guard {
+                            all_closed = false;
+                            if let Ok(val) = rx.try_recv() {
+                                return Ok(Value::Array(vec![Value::Int(idx as i64), val]));
+                            }
+                        }
+                    }
+                    if all_closed {
+                        return Ok(Value::Null);
+                    }
+                    offset += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            }
             _ if name.starts_with("math.") => {
                 crate::stdlib::math::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1319,15 +1319,22 @@ impl Interpreter {
                 if channels.is_empty() {
                     return Err(RuntimeError::new("select() requires a non-empty array"));
                 }
+                let timeout_ms: Option<u128> = match args.get(1) {
+                    Some(Value::Int(ms)) => Some((*ms).max(0) as u128),
+                    Some(Value::Float(s)) => Some((s * 1000.0).max(0.0) as u128),
+                    _ => None,
+                };
+                let start = std::time::Instant::now();
                 let len = channels.len();
                 let mut offset = 0usize;
                 loop {
                     let mut all_closed = true;
                     for i in 0..len {
                         let idx = (i + offset) % len;
-                        let rx_guard = channels[idx].rx.lock().map_err(|e| {
-                            RuntimeError::new(&format!("channel lock error: {}", e))
-                        })?;
+                        let rx_guard = channels[idx]
+                            .rx
+                            .lock()
+                            .expect("BUG: channel mutex poisoned");
                         if let Some(ref rx) = *rx_guard {
                             all_closed = false;
                             if let Ok(val) = rx.try_recv() {
@@ -1338,7 +1345,12 @@ impl Interpreter {
                     if all_closed {
                         return Ok(Value::Null);
                     }
-                    offset += 1;
+                    if let Some(ms) = timeout_ms {
+                        if start.elapsed().as_millis() >= ms {
+                            return Ok(Value::Null);
+                        }
+                    }
+                    offset = (offset + 1) % len;
                     std::thread::sleep(std::time::Duration::from_millis(1));
                 }
             }

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1321,7 +1321,7 @@ impl Interpreter {
                 }
                 let timeout_ms: Option<u128> = match args.get(1) {
                     Some(Value::Int(ms)) => Some((*ms).max(0) as u128),
-                    Some(Value::Float(s)) => Some((s * 1000.0).max(0.0) as u128),
+                    Some(Value::Float(ms)) => Some(ms.max(0.0) as u128),
                     _ => None,
                 };
                 let start = std::time::Instant::now();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -648,6 +648,7 @@ impl Interpreter {
             "assert_throws",
             "try_send",
             "try_receive",
+            "select",
             // GenZ Debug Kit
             "sus",
             "bruh",

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3907,6 +3907,66 @@ fn channel_send_receive_multiple() {
     assert!(result.is_ok(), "channel multi: {:?}", result.err());
 }
 
+#[test]
+fn select_returns_ready_channel() {
+    let result = try_run_forge(
+        r#"
+        let ch1 = channel()
+        let ch2 = channel()
+        spawn { send(ch2, "hello") }
+        wait 0.05 seconds
+        let result = select([ch1, ch2])
+        assert_eq(result[0], 1)
+        assert_eq(result[1], "hello")
+    "#,
+    );
+    assert!(result.is_ok(), "select ready: {:?}", result.err());
+}
+
+#[test]
+fn select_returns_correct_index() {
+    let result = try_run_forge(
+        r#"
+        let ch1 = channel()
+        let ch2 = channel()
+        let ch3 = channel()
+        spawn { send(ch1, 42) }
+        wait 0.05 seconds
+        let result = select([ch1, ch2, ch3])
+        assert_eq(result[0], 0)
+        assert_eq(result[1], 42)
+    "#,
+    );
+    assert!(result.is_ok(), "select index: {:?}", result.err());
+}
+
+#[test]
+fn select_single_channel() {
+    let result = try_run_forge(
+        r#"
+        let ch = channel()
+        spawn { send(ch, "only") }
+        wait 0.05 seconds
+        let result = select([ch])
+        assert_eq(result[0], 0)
+        assert_eq(result[1], "only")
+    "#,
+    );
+    assert!(result.is_ok(), "select single: {:?}", result.err());
+}
+
+#[test]
+fn select_empty_array_errors() {
+    let result = try_run_forge("select([])");
+    assert!(result.is_err());
+}
+
+#[test]
+fn select_non_array_errors() {
+    let result = try_run_forge("select(42)");
+    assert!(result.is_err());
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3967,6 +3967,17 @@ fn select_non_array_errors() {
     assert!(result.is_err());
 }
 
+#[test]
+fn select_timeout_returns_null() {
+    let value = run_forge(
+        r#"
+        let ch = channel()
+        select([ch], 50)
+    "#,
+    );
+    assert_eq!(value, Value::Null);
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1723,6 +1723,11 @@ impl Parser {
                 Ok(Expr::Ident("type".to_string()))
             }
 
+            Token::Select => {
+                self.advance();
+                Ok(Expr::Ident("select".to_string()))
+            }
+
             Token::Fn => {
                 self.advance();
                 self.expect(Token::LParen)?;


### PR DESCRIPTION
## Summary

- Adds select(channels) builtin that waits on multiple channels and returns [index, value] for the first ready channel
- Uses polling loop with try_recv() and rotating start index to avoid starvation
- Returns Null when all channels are closed
- Handles Token::Select in parser parse_primary so select(...) parses as a function call

**Roadmap item:** 9A.1 -- Channel select

## Test plan

- [x] select returns the correct index and value for the ready channel
- [x] select with single channel works (returns [0, value])
- [x] select on empty array errors
- [x] select on non-array errors
- [x] Full test suite passes (1029 tests)