### PR TITLE
feat: add channel close and for-in iteration (9A.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`select(channels, timeout?)` builtin** — wait on multiple channels, returns `[index, value]` for the first ready channel. Optional timeout in ms. ([#69](https://github.com/humancto/forge-lang/pull/69))
+- **`close(ch)` builtin and channel iteration** — close a channel to signal no more values; `for msg in ch { }` drains until closed. ([#70](https://github.com/humancto/forge-lang/pull/70))
 
 ## [0.8.0] - 2026-04-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ run, repl, version, fmt, test, new, build, install, publish, lsp, dap, learn, ch
 - Validation: assert, assert_eq, assert_ne, assert_throws, satisfies
 - GenZ Debug Kit: sus (inspect), bruh (panic), bet (assert), no_cap (assert_eq), ick (assert-false)
 - Execution: cook (profiling), yolo (fire-and-forget), ghost (silent exec), slay (benchmarking)
-- Concurrency: channel, send, receive, try_send, try_receive, select
+- Concurrency: channel, send, receive, try_send, try_receive, select, close
 
 ## Build & Test
 

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1354,6 +1354,18 @@ impl Interpreter {
                     std::thread::sleep(std::time::Duration::from_millis(1));
                 }
             }
+            "close" => {
+                if args.is_empty() {
+                    return Err(RuntimeError::new("close() requires a channel"));
+                }
+                match &args[0] {
+                    Value::Channel(ch) => {
+                        *ch.tx.lock().expect("BUG: channel mutex poisoned") = None;
+                        Ok(Value::Null)
+                    }
+                    _ => Err(RuntimeError::new("close() requires a channel")),
+                }
+            }
             _ if name.starts_with("math.") => {
                 crate::stdlib::math::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -649,6 +649,7 @@ impl Interpreter {
             "try_send",
             "try_receive",
             "select",
+            "close",
             // GenZ Debug Kit
             "sus",
             "bruh",
@@ -1173,7 +1174,42 @@ impl Interpreter {
                             }
                         }
                     }
-                    _ => return Err(RuntimeError::new("can only iterate over arrays or objects")),
+                    Value::Channel(ch) => loop {
+                        let val = {
+                            let rx_guard = ch.rx.lock().expect("BUG: channel mutex poisoned");
+                            match rx_guard.as_ref() {
+                                Some(rx) => match rx.recv() {
+                                    Ok(v) => v,
+                                    Err(_) => break,
+                                },
+                                None => break,
+                            }
+                        };
+                        self.env.push_scope();
+                        self.env.define(var.clone(), val);
+                        match self.exec_block(body)? {
+                            Signal::Break => {
+                                self.env.pop_scope();
+                                break;
+                            }
+                            Signal::Continue => {
+                                self.env.pop_scope();
+                                continue;
+                            }
+                            Signal::Return(v) => {
+                                self.env.pop_scope();
+                                return Ok(Signal::Return(v));
+                            }
+                            Signal::None | Signal::ImplicitReturn(_) => {
+                                self.env.pop_scope();
+                            }
+                        }
+                    },
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "can only iterate over arrays, objects, or channels",
+                        ))
+                    }
                 }
                 Ok(Signal::None)
             }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -3978,6 +3978,69 @@ fn select_timeout_returns_null() {
     assert_eq!(value, Value::Null);
 }
 
+#[test]
+fn close_channel_then_receive_returns_null() {
+    let result = try_run_forge(
+        r#"
+        let ch = channel()
+        send(ch, 1)
+        receive(ch)
+        close(ch)
+        let r = try_receive(ch)
+        assert(is_none(r))
+    "#,
+    );
+    assert!(result.is_ok(), "close+receive: {:?}", result.err());
+}
+
+#[test]
+fn close_non_channel_errors() {
+    let result = try_run_forge("close(42)");
+    assert!(result.is_err());
+}
+
+#[test]
+fn close_no_args_errors() {
+    let result = try_run_forge("close()");
+    assert!(result.is_err());
+}
+
+#[test]
+fn for_in_channel_drains_and_exits() {
+    let result = try_run_forge(
+        r#"
+        let ch = channel()
+        spawn {
+            send(ch, 1)
+            send(ch, 2)
+            send(ch, 3)
+            close(ch)
+        }
+        let mut items = []
+        for msg in ch {
+            items = push(items, msg)
+        }
+        assert_eq(len(items), 3)
+        assert_eq(items[0], 1)
+        assert_eq(items[1], 2)
+        assert_eq(items[2], 3)
+    "#,
+    );
+    assert!(result.is_ok(), "for-in channel: {:?}", result.err());
+}
+
+#[test]
+fn send_after_close_errors() {
+    let result = try_run_forge(
+        r#"
+        let ch = channel()
+        close(ch)
+        send(ch, 1)
+    "#,
+    );
+    assert!(result.is_err());
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -4030,6 +4030,28 @@ fn for_in_channel_drains_and_exits() {
 }
 
 #[test]
+fn for_in_channel_break_stops_early() {
+    let result = try_run_forge(
+        r#"
+        let ch = channel()
+        spawn {
+            send(ch, 10)
+            send(ch, 20)
+            send(ch, 30)
+            close(ch)
+        }
+        let mut first = 0
+        for msg in ch {
+            first = msg
+            break
+        }
+        assert_eq(first, 10)
+    "#,
+    );
+    assert!(result.is_ok(), "for-in break: {:?}", result.err());
+}
+
+#[test]
 fn send_after_close_errors() {
     let result = try_run_forge(
         r#"


### PR DESCRIPTION
## Summary

- Adds `close(ch)` builtin that drops the sender, signaling no more values will be sent
- Adds `Value::Channel` support in `for msg in ch { }` loops to drain a channel until closed
- Enables clean producer-consumer patterns with shutdown

**Roadmap item:** 9A.2 -- Channel close and iteration

## Test plan

- [x] close then try_receive returns None (channel drained)
- [x] close non-channel errors
- [x] close with no args errors
- [x] for-in channel drains all values and exits after close
- [x] send after close errors
- [x] Full test suite passes (1035 tests)