### PR TITLE
feat: add await_all builtin for task groups (9B.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`select(channels, timeout?)` builtin** — wait on multiple channels, returns `[index, value]` for the first ready channel. Optional timeout in ms. ([#69](https://github.com/humancto/forge-lang/pull/69))
 - **`close(ch)` builtin and channel iteration** — close a channel to signal no more values; `for msg in ch { }` drains until closed. ([#70](https://github.com/humancto/forge-lang/pull/70))
 - **Unbounded channels** — `channel()` with no args creates an unbounded channel; `channel(n)` creates bounded as before. ([#71](https://github.com/humancto/forge-lang/pull/71))
+- **`await_all(handles)` builtin** — wait for multiple spawned tasks and collect results into an array. ([#72](https://github.com/humancto/forge-lang/pull/72))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1379,6 +1379,41 @@ impl Interpreter {
                     _ => Err(RuntimeError::new("close() requires a channel")),
                 }
             }
+            "await_all" => {
+                if args.is_empty() {
+                    return Err(RuntimeError::new(
+                        "await_all() requires an array of task handles",
+                    ));
+                }
+                let handles = match &args[0] {
+                    Value::Array(items) => items.clone(),
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "await_all() requires an array of task handles",
+                        ))
+                    }
+                };
+                let mut results = Vec::with_capacity(handles.len());
+                for (i, handle) in handles.into_iter().enumerate() {
+                    match handle {
+                        Value::TaskHandle(slot) => {
+                            let (lock, cvar) = &*slot;
+                            let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                            while guard.is_none() {
+                                guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
+                            }
+                            results.push(guard.take().unwrap_or(Value::Null));
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(&format!(
+                                "await_all() element at index {} is not a task handle",
+                                i
+                            )))
+                        }
+                    }
+                }
+                Ok(Value::Array(results))
+            }
             _ if name.starts_with("math.") => {
                 crate::stdlib::math::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -657,6 +657,7 @@ impl Interpreter {
             "try_receive",
             "select",
             "close",
+            "await_all",
             // GenZ Debug Kit
             "sus",
             "bruh",

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -4109,6 +4109,41 @@ fn send_after_close_errors() {
     assert!(result.is_err());
 }
 
+#[test]
+fn await_all_collects_results() {
+    let result = try_run_forge(
+        r#"
+        let h1 = spawn { 10 }
+        let h2 = spawn { 20 }
+        let h3 = spawn { 30 }
+        let results = await_all([h1, h2, h3])
+        assert_eq(len(results), 3)
+        assert_eq(results[0], 10)
+        assert_eq(results[1], 20)
+        assert_eq(results[2], 30)
+    "#,
+    );
+    assert!(result.is_ok(), "await_all: {:?}", result.err());
+}
+
+#[test]
+fn await_all_empty_array() {
+    let value = run_forge("await_all([])");
+    assert_eq!(value, Value::Array(vec![]));
+}
+
+#[test]
+fn await_all_non_handle_errors() {
+    let result = try_run_forge("await_all([42])");
+    assert!(result.is_err());
+}
+
+#[test]
+fn await_all_non_array_errors() {
+    let result = try_run_forge("await_all(42)");
+    assert!(result.is_err());
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `await_all(handles)` builtin that waits for multiple spawned tasks and returns results as an array
- Handles mutex poisoning via `unwrap_or_else(|e| e.into_inner())` for robustness
- Validates input: requires array of TaskHandles, errors on non-handle elements with index info

**Roadmap item:** 9B.1 -- Task groups

## Test plan

- [x] await_all with 3 tasks returns all results in order
- [x] await_all with empty array returns []
- [x] await_all with non-handle element errors
- [x] await_all with non-array argument errors
- [x] Full test suite passes (1043 tests)