### PR TITLE
feat: add await_timeout builtin (9B.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`close(ch)` builtin and channel iteration** — close a channel to signal no more values; `for msg in ch { }` drains until closed. ([#70](https://github.com/humancto/forge-lang/pull/70))
 - **Unbounded channels** — `channel()` with no args creates an unbounded channel; `channel(n)` creates bounded as before. ([#71](https://github.com/humancto/forge-lang/pull/71))
 - **`await_all(handles)` builtin** — wait for multiple spawned tasks and collect results into an array. ([#72](https://github.com/humancto/forge-lang/pull/72))
+- **`await_timeout(handle, ms)` builtin** — wait for a task with a deadline; returns Null on timeout. ([#73](https://github.com/humancto/forge-lang/pull/73))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1414,6 +1414,41 @@ impl Interpreter {
                 }
                 Ok(Value::Array(results))
             }
+            "await_timeout" => {
+                if args.len() < 2 {
+                    return Err(RuntimeError::new(
+                        "await_timeout() requires (handle, timeout_ms)",
+                    ));
+                }
+                let timeout_ms = match &args[1] {
+                    Value::Int(ms) => (*ms).max(0) as u64,
+                    Value::Float(ms) => ms.max(0.0) as u64,
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "await_timeout() second argument must be a number (ms)",
+                        ))
+                    }
+                };
+                match &args[0] {
+                    Value::TaskHandle(slot) => {
+                        let (lock, cvar) = &**slot;
+                        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                        if guard.is_none() {
+                            let (g, timeout_result) = cvar
+                                .wait_timeout(guard, std::time::Duration::from_millis(timeout_ms))
+                                .unwrap_or_else(|e| e.into_inner());
+                            guard = g;
+                            if timeout_result.timed_out() && guard.is_none() {
+                                return Ok(Value::Null);
+                            }
+                        }
+                        Ok(guard.take().unwrap_or(Value::Null))
+                    }
+                    _ => Err(RuntimeError::new(
+                        "await_timeout() first argument must be a task handle",
+                    )),
+                }
+            }
             _ if name.starts_with("math.") => {
                 crate::stdlib::math::call(name, args).map_err(|e| RuntimeError::new(&e))
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -658,6 +658,7 @@ impl Interpreter {
             "select",
             "close",
             "await_all",
+            "await_timeout",
             // GenZ Debug Kit
             "sus",
             "bruh",

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -4144,6 +4144,35 @@ fn await_all_non_array_errors() {
     assert!(result.is_err());
 }
 
+#[test]
+fn await_timeout_returns_value_when_fast() {
+    let result = try_run_forge(
+        r#"
+        let h = spawn { 42 }
+        let val = await_timeout(h, 5000)
+        assert_eq(val, 42)
+    "#,
+    );
+    assert!(result.is_ok(), "await_timeout fast: {:?}", result.err());
+}
+
+#[test]
+fn await_timeout_returns_null_on_timeout() {
+    let value = run_forge(
+        r#"
+        let h = spawn { wait 10 seconds }
+        await_timeout(h, 50)
+    "#,
+    );
+    assert_eq!(value, Value::Null);
+}
+
+#[test]
+fn await_timeout_non_handle_errors() {
+    let result = try_run_forge("await_timeout(42, 100)");
+    assert!(result.is_err());
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `await_timeout(handle, ms)` that waits for a spawned task with a deadline
- Uses `Condvar::wait_timeout` — returns task value on success, Null on timeout
- Handles mutex poisoning via `unwrap_or_else`

**Roadmap item:** 9B.2 -- Spawn with timeout

## Test plan

- [x] Fast task returns value before timeout
- [x] Slow task returns Null on timeout
- [x] Non-handle argument errors
- [x] Full test suite passes (1046 tests)