### PR TITLE
feat: spawn Result wrapping and error propagation (9B.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unbounded channels** — `channel()` with no args creates an unbounded channel; `channel(n)` creates bounded as before. ([#71](https://github.com/humancto/forge-lang/pull/71))
 - **`await_all(handles)` builtin** — wait for multiple spawned tasks and collect results into an array. ([#72](https://github.com/humancto/forge-lang/pull/72))
 - **`await_timeout(handle, ms)` builtin** — wait for a task with a deadline; returns Null on timeout. ([#73](https://github.com/humancto/forge-lang/pull/73))
+- **Spawn Result wrapping** — spawned tasks wrap results in Ok/Err; `await` auto-unwraps Ok and propagates Err as runtime errors. ([#74](https://github.com/humancto/forge-lang/pull/74))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/interpreter/builtins.rs
+++ b/src/interpreter/builtins.rs
@@ -1402,7 +1402,14 @@ impl Interpreter {
                             while guard.is_none() {
                                 guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
                             }
-                            results.push(guard.take().unwrap_or(Value::Null));
+                            let result = guard.take().unwrap_or(Value::Null);
+                            match result {
+                                Value::ResultOk(v) => results.push(*v),
+                                Value::ResultErr(e) => {
+                                    return Err(RuntimeError::new(&format!("task error: {}", e)))
+                                }
+                                other => results.push(other),
+                            }
                         }
                         _ => {
                             return Err(RuntimeError::new(&format!(
@@ -1442,7 +1449,14 @@ impl Interpreter {
                                 return Ok(Value::Null);
                             }
                         }
-                        Ok(guard.take().unwrap_or(Value::Null))
+                        let result = guard.take().unwrap_or(Value::Null);
+                        match result {
+                            Value::ResultOk(v) => Ok(*v),
+                            Value::ResultErr(e) => {
+                                Err(RuntimeError::new(&format!("task error: {}", e)))
+                            }
+                            other => Ok(other),
+                        }
                     }
                     _ => Err(RuntimeError::new(
                         "await_timeout() first argument must be a task handle",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2533,7 +2533,14 @@ impl Interpreter {
                                 .wait(guard)
                                 .map_err(|_| RuntimeError::new("await: condvar wait failed"))?;
                         }
-                        Ok(guard.take().unwrap_or(Value::Null))
+                        let result = guard.take().unwrap_or(Value::Null);
+                        match result {
+                            Value::ResultOk(v) => Ok(*v),
+                            Value::ResultErr(e) => {
+                                Err(RuntimeError::new(&format!("task error: {}", e)))
+                            }
+                            other => Ok(other),
+                        }
                     }
                     // Non-handle values pass through (backward compatible)
                     other => Ok(other),
@@ -3065,12 +3072,11 @@ impl Interpreter {
         std::thread::spawn(move || {
             let result = spawn_interp.exec_block(&body);
             let val = match result {
-                Ok(Signal::Return(v)) | Ok(Signal::ImplicitReturn(v)) => v,
-                Ok(_) => Value::Null,
-                Err(e) => {
-                    eprintln!("spawn error: {}", e.message);
-                    Value::Null
+                Ok(Signal::Return(v)) | Ok(Signal::ImplicitReturn(v)) => {
+                    Value::ResultOk(Box::new(v))
                 }
+                Ok(_) => Value::ResultOk(Box::new(Value::Null)),
+                Err(e) => Value::ResultErr(Box::new(Value::String(e.message))),
             };
             let (lock, cvar) = &*slot_clone;
             if let Ok(mut guard) = lock.lock() {

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -4173,6 +4173,41 @@ fn await_timeout_non_handle_errors() {
     assert!(result.is_err());
 }
 
+#[test]
+fn spawn_result_ok_unwrapped_by_await() {
+    let result = try_run_forge(
+        r#"
+        let h = spawn { 42 }
+        let val = await h
+        assert_eq(val, 42)
+    "#,
+    );
+    assert!(result.is_ok(), "spawn result ok: {:?}", result.err());
+}
+
+#[test]
+fn spawn_error_propagated_by_await() {
+    let result = try_run_forge(
+        r#"
+        let h = spawn { 1 / 0 }
+        await h
+    "#,
+    );
+    assert!(result.is_err(), "spawn error should propagate");
+}
+
+#[test]
+fn await_all_propagates_task_error() {
+    let result = try_run_forge(
+        r#"
+        let h1 = spawn { 10 }
+        let h2 = spawn { 1 / 0 }
+        await_all([h1, h2])
+    "#,
+    );
+    assert!(result.is_err());
+}
+
 // === Phase 2: Short-circuit tests ===
 
 #[test]


### PR DESCRIPTION
## Summary

- Spawned tasks now wrap results in `Ok(value)` and errors in `Err(message)`
- `await` auto-unwraps `Ok` (backward compatible) and propagates `Err` as runtime errors
- `await_all` and `await_timeout` also unwrap/propagate consistently
- Previously, task errors were silently printed to stderr and returned as Null

**Roadmap item:** 9B.3 -- Spawn return type

## Test plan

- [x] await on successful task returns unwrapped value (42, not Ok(42))
- [x] await on failed task propagates error to caller
- [x] await_all propagates first task error
- [x] Full test suite passes (1049 tests)