### PR TITLE
feat: GitHub-based remote package registry

### DIFF
--- a/.planning/github-registry.plan.md
+++ b/.planning/github-registry.plan.md
@@ -1,0 +1,94 @@
+# Plan: 10B.1 — GitHub-based package index
+
+## Goal
+
+Allow `forge install` to fetch packages from a central GitHub-hosted registry index.
+
+## Design
+
+### Index Format
+
+Registry is a GitHub repo (default: `forge-lang/registry`). Each package has a TOML file:
+
+```
+packages/<name>.toml
+```
+
+```toml
+[package]
+name = "router"
+description = "HTTP router for Forge"
+repository = "https://github.com/user/forge-router"
+
+[[versions]]
+version = "1.0.0"
+url = "https://github.com/user/forge-router/archive/refs/tags/v1.0.0.tar.gz"
+checksum = "sha256:abc123..."
+
+[[versions]]
+version = "2.0.0"
+url = "https://github.com/user/forge-router/archive/refs/tags/v2.0.0.tar.gz"
+checksum = "sha256:def456..."
+```
+
+### Implementation
+
+1. **Data types** in `src/registry.rs` (new file):
+   - `PackageEntry { name, description, repository, versions: Vec<VersionEntry> }`
+   - `VersionEntry { version, url, checksum }`
+   - `parse_package_entry(toml_str) -> Result<PackageEntry, String>`
+
+2. **Remote fetch**:
+   - `fetch_package_entry(name, registry_url) -> Result<PackageEntry, String>`
+   - URL: `{registry_url}/packages/{name}.toml`
+   - Default registry URL from `FORGE_REGISTRY_URL` env var or `https://raw.githubusercontent.com/forge-lang/registry/main`
+   - Accept `GITHUB_TOKEN` env var for auth header (rate limit mitigation)
+   - Uses `reqwest::blocking` (already in crate for runtime client)
+
+3. **Local cache**:
+   - Cache fetched entries at `.forge/cache/registry/<name>.toml`
+   - TTL: 1 hour (configurable via `FORGE_CACHE_TTL` env var in seconds)
+   - Atomic writes: write to temp file, then rename
+
+4. **Download + extract**:
+   - `download_and_extract(url, dest_dir) -> Result<(), String>`
+   - Download tarball to temp file
+   - Extract to temp directory, then rename to final location (atomic)
+   - If tarball contains a single root directory (GitHub archive style), flatten it
+
+5. **Integration in `package.rs`**:
+   - Update `install_from_registry_as()`: after local registry lookup fails, try remote
+   - Resolve semver against remote `VersionEntry` list
+   - Download and extract the resolved version
+   - Lockfile already handles recording installed version
+
+### Files to touch
+
+1. **`src/registry.rs`** (new) — remote registry types, fetch, cache, download
+2. **`src/package.rs`** — integrate remote fallback in `install_from_registry_as()`
+3. **`src/main.rs`** — add `mod registry`
+
+### Edge cases
+
+- Network unavailable → fall back to local registry only, print warning
+- Package not in remote index → clear error listing where we looked
+- Download/extraction fails → clean up temp files, error with URL
+- Cache fresh → skip network fetch
+- Checksum empty → warn but allow (full enforcement in 10B.3)
+
+### Out of scope
+
+- Publish flow (how packages get into the registry repo)
+- Version yanking
+- Full checksum enforcement (10B.3)
+
+## Test strategy
+
+- Parse a PackageEntry from TOML string
+- Semver resolution against VersionEntry list (reuse resolve logic)
+- Cache TTL logic (fresh vs stale)
+- Integration tests require network, skip in CI
+
+## Rollback
+
+Delete `src/registry.rs`, revert `src/package.rs` and `src/main.rs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Semver constraint parsing** — `forge.toml` dependency specs now support `^1.0`, `~1.5`, `>=1.0.0, <2.0.0`, `*` version constraints via the `semver` crate. ([#75](https://github.com/humancto/forge-lang/pull/75))
 - **Semver resolution algorithm** — `forge install` now resolves the latest compatible version from the registry instead of requiring exact version matches. Includes directory traversal protection and helpful error messages listing available versions. ([#76](https://github.com/humancto/forge-lang/pull/76))
 - **Transitive dependency resolution** — `forge install` now recursively resolves and installs transitive dependencies from `forge.toml`. Detects circular dependencies and handles diamond dependency patterns. ([#77](https://github.com/humancto/forge-lang/pull/77))
+- **GitHub-based remote package registry** — `forge install` now falls back to a remote GitHub-based package index when local registry lookup fails. Supports TOML-based package entries, semver resolution, tarball download/extraction, local caching with TTL, and `GITHUB_TOKEN` authentication. ([#78](https://github.com/humancto/forge-lang/pull/78))
 
 ## [0.8.0] - 2026-04-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +900,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -1485,6 +1497,7 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1784,7 +1797,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2101,6 +2114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2185,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2597,6 +2620,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3710,6 +3744,16 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # === HTTP Client (production-grade) ===
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "blocking"] }
 
 # === CLI & REPL ===
 clap = { version = "4", features = ["derive"] }
@@ -87,6 +87,7 @@ cranelift-module = { version = "0.129", optional = true }
 cranelift-native = { version = "0.129", optional = true }
 gethostname = "1.1.0"
 semver = "1"
+tar = "0.4"
 
 [features]
 default = ["jit", "postgres", "mysql"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod package;
 mod permissions;
 mod parser;
 mod publish;
+mod registry;
 mod repl;
 mod runtime;
 mod scaffold;

--- a/src/package.rs
+++ b/src/package.rs
@@ -322,6 +322,8 @@ fn install_from_remote_registry(
 ) -> Result<LockedPackage, String> {
     use crate::registry;
 
+    validate_package_name(name)?;
+
     let entry = match registry::fetch_package_entry(name) {
         Ok(Some(e)) => e,
         Ok(None) => {
@@ -351,7 +353,7 @@ fn install_from_remote_registry(
         "  Downloading {} @ {} from remote registry...",
         name, resolved.version
     );
-    registry::download_and_extract(&resolved.url, &packages_dir.join(name))?;
+    registry::download_and_extract(&resolved.url, &packages_dir.join(name), &resolved.checksum)?;
     println!(
         "  \x1B[32m✓\x1B[0m Installed {} @ {} (remote)",
         name, resolved.version

--- a/src/package.rs
+++ b/src/package.rs
@@ -296,17 +296,72 @@ fn install_from_registry_as(
         })?
     };
 
-    let (resolved_version, source) = resolve_best_version(name, &req, registry_roots)?;
-    install_from_path_as(name, &source, packages_dir)?;
+    // Try local registry first
+    if let Ok((resolved_version, source)) = resolve_best_version(name, &req, registry_roots) {
+        install_from_path_as(name, &source, packages_dir)?;
+        println!(
+            "  \x1B[32m✓\x1B[0m Installed {} @ {}",
+            name, resolved_version
+        );
+        return Ok(LockedPackage {
+            name: name.to_string(),
+            version: resolved_version,
+            source: format!("registry+{}", source.display()),
+            checksum: String::new(),
+        });
+    }
+
+    // Fall back to remote registry
+    install_from_remote_registry(name, &req, packages_dir)
+}
+
+fn install_from_remote_registry(
+    name: &str,
+    req: &VersionReq,
+    packages_dir: &Path,
+) -> Result<LockedPackage, String> {
+    use crate::registry;
+
+    let entry = match registry::fetch_package_entry(name) {
+        Ok(Some(e)) => e,
+        Ok(None) => {
+            return Err(format!(
+                "  Error: package '{}' not found in local or remote registry",
+                name
+            ));
+        }
+        Err(e) => {
+            return Err(format!(
+                "  Error: failed to fetch '{}' from remote registry: {}",
+                name, e
+            ));
+        }
+    };
+
+    let resolved = registry::resolve_remote_version(name, req, &entry.versions)?;
+
+    if resolved.checksum.is_empty() {
+        eprintln!(
+            "  Warning: no checksum for {} @ {} — integrity not verified",
+            name, resolved.version
+        );
+    }
+
     println!(
-        "  \x1B[32m✓\x1B[0m Installed {} @ {}",
-        name, resolved_version
+        "  Downloading {} @ {} from remote registry...",
+        name, resolved.version
     );
+    registry::download_and_extract(&resolved.url, &packages_dir.join(name))?;
+    println!(
+        "  \x1B[32m✓\x1B[0m Installed {} @ {} (remote)",
+        name, resolved.version
+    );
+
     Ok(LockedPackage {
         name: name.to_string(),
-        version: resolved_version,
-        source: format!("registry+{}", source.display()),
-        checksum: String::new(),
+        version: resolved.version,
+        source: format!("remote+{}", resolved.url),
+        checksum: resolved.checksum,
     })
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,424 @@
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+const DEFAULT_REGISTRY_URL: &str = "https://raw.githubusercontent.com/forge-lang/registry/main";
+const DEFAULT_CACHE_TTL_SECS: u64 = 3600; // 1 hour
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PackageEntry {
+    pub package: PackageMeta,
+    #[serde(default)]
+    pub versions: Vec<VersionEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PackageMeta {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub repository: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct VersionEntry {
+    pub version: String,
+    pub url: String,
+    #[serde(default)]
+    pub checksum: String,
+}
+
+/// Get the configured registry base URL.
+pub fn registry_url() -> String {
+    env::var("FORGE_REGISTRY_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_URL.to_string())
+}
+
+/// Get the cache directory for registry data.
+fn cache_dir() -> PathBuf {
+    PathBuf::from(".forge").join("cache").join("registry")
+}
+
+/// Get the configured cache TTL.
+fn cache_ttl() -> Duration {
+    let secs = env::var("FORGE_CACHE_TTL")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CACHE_TTL_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Check if a cached file is still fresh.
+fn is_cache_fresh(path: &Path) -> bool {
+    let metadata = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    let modified = match metadata.modified() {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    match SystemTime::now().duration_since(modified) {
+        Ok(age) => age < cache_ttl(),
+        Err(_) => false,
+    }
+}
+
+/// Write to a file atomically (write to temp, then rename).
+fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temp = path.with_extension("tmp");
+    std::fs::write(&temp, content)?;
+    std::fs::rename(&temp, path)?;
+    Ok(())
+}
+
+/// Fetch a package entry from the remote registry.
+/// Returns the parsed entry, or None if the package is not found.
+/// Uses local cache when fresh.
+pub fn fetch_package_entry(name: &str) -> Result<Option<PackageEntry>, String> {
+    let cache_path = cache_dir().join(format!("{}.toml", name));
+
+    // Check cache first
+    if is_cache_fresh(&cache_path) {
+        let content = std::fs::read_to_string(&cache_path)
+            .map_err(|e| format!("failed to read cache: {}", e))?;
+        let entry: PackageEntry =
+            toml::from_str(&content).map_err(|e| format!("corrupt cache for '{}': {}", name, e))?;
+        return Ok(Some(entry));
+    }
+
+    // Fetch from remote
+    let base_url = registry_url();
+    let url = format!("{}/packages/{}.toml", base_url, name);
+
+    let mut builder = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("failed to create HTTP client: {}", e))?
+        .get(&url);
+
+    // Add auth token if available (rate limit mitigation)
+    if let Ok(token) = env::var("GITHUB_TOKEN") {
+        builder = builder.header("Authorization", format!("token {}", token));
+    }
+
+    let response = builder
+        .send()
+        .map_err(|e| format!("failed to fetch '{}': {}", url, e))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "registry returned {} for '{}'",
+            response.status(),
+            name
+        ));
+    }
+
+    let body = response
+        .text()
+        .map_err(|e| format!("failed to read response: {}", e))?;
+
+    let entry: PackageEntry = toml::from_str(&body)
+        .map_err(|e| format!("invalid package entry for '{}': {}", name, e))?;
+
+    // Cache the result atomically
+    if let Err(e) = atomic_write(&cache_path, body.as_bytes()) {
+        eprintln!(
+            "  Warning: failed to cache registry entry for '{}': {}",
+            name, e
+        );
+    }
+
+    Ok(Some(entry))
+}
+
+/// Resolve the best version from a list of version entries using semver.
+pub fn resolve_remote_version(
+    name: &str,
+    req: &semver::VersionReq,
+    versions: &[VersionEntry],
+) -> Result<VersionEntry, String> {
+    let mut parsed: Vec<(semver::Version, &VersionEntry)> = versions
+        .iter()
+        .filter_map(|ve| semver::Version::parse(&ve.version).ok().map(|v| (v, ve)))
+        .collect();
+
+    if parsed.is_empty() {
+        return Err(format!(
+            "  Error: no valid versions found for '{}' in remote registry",
+            name
+        ));
+    }
+
+    let best = parsed
+        .iter()
+        .filter(|(v, _)| req.matches(v))
+        .max_by(|(a, _), (b, _)| a.cmp(b));
+
+    match best {
+        Some((_, entry)) => Ok((*entry).clone()),
+        None => {
+            parsed.sort_by(|(a, _), (b, _)| a.cmp(b));
+            let available: Vec<&str> = parsed.iter().map(|(_, ve)| ve.version.as_str()).collect();
+            Err(format!(
+                "  Error: no version of '{}' matches '{}' (available: {})",
+                name,
+                req,
+                available.join(", ")
+            ))
+        }
+    }
+}
+
+/// Download a file from a URL to a destination path.
+/// Uses atomic write (download to temp, then rename).
+pub fn download_to(url: &str, dest: &Path) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create directory: {}", e))?;
+    }
+
+    let mut builder = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .map_err(|e| format!("failed to create HTTP client: {}", e))?
+        .get(url);
+
+    if let Ok(token) = env::var("GITHUB_TOKEN") {
+        builder = builder.header("Authorization", format!("token {}", token));
+    }
+
+    let response = builder
+        .send()
+        .map_err(|e| format!("failed to download '{}': {}", url, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "download failed with {} for '{}'",
+            response.status(),
+            url
+        ));
+    }
+
+    let bytes = response
+        .bytes()
+        .map_err(|e| format!("failed to read download: {}", e))?;
+
+    let temp = dest.with_extension("download");
+    std::fs::write(&temp, &bytes).map_err(|e| format!("failed to write temp file: {}", e))?;
+    std::fs::rename(&temp, dest).map_err(|e| format!("failed to finalize download: {}", e))?;
+
+    Ok(())
+}
+
+/// Download a tarball and extract it to a destination directory.
+/// Handles GitHub-style archives that contain a single root directory.
+pub fn download_and_extract(url: &str, dest: &Path) -> Result<(), String> {
+    let temp_dir = dest.with_extension("extracting");
+    if temp_dir.exists() {
+        std::fs::remove_dir_all(&temp_dir)
+            .map_err(|e| format!("failed to clean temp dir: {}", e))?;
+    }
+
+    let temp_archive = dest.with_extension("tar.gz");
+    download_to(url, &temp_archive)?;
+
+    // Extract the archive
+    let file =
+        std::fs::File::open(&temp_archive).map_err(|e| format!("failed to open archive: {}", e))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    std::fs::create_dir_all(&temp_dir).map_err(|e| format!("failed to create temp dir: {}", e))?;
+
+    archive
+        .unpack(&temp_dir)
+        .map_err(|e| format!("failed to extract archive: {}", e))?;
+
+    // Clean up the archive
+    let _ = std::fs::remove_file(&temp_archive);
+
+    // GitHub archives contain a single root directory (e.g., "repo-v1.0.0/")
+    // Flatten if there's exactly one subdirectory
+    let entries: Vec<_> = std::fs::read_dir(&temp_dir)
+        .map_err(|e| format!("failed to read extracted dir: {}", e))?
+        .filter_map(|e| e.ok())
+        .collect();
+
+    if dest.exists() {
+        std::fs::remove_dir_all(dest)
+            .map_err(|e| format!("failed to remove existing package: {}", e))?;
+    }
+
+    if entries.len() == 1 && entries[0].file_type().map_or(false, |t| t.is_dir()) {
+        // Single root directory — move it to dest
+        std::fs::rename(entries[0].path(), dest)
+            .map_err(|e| format!("failed to move extracted package: {}", e))?;
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    } else {
+        // Multiple entries or flat — rename the temp dir itself
+        std::fs::rename(&temp_dir, dest)
+            .map_err(|e| format!("failed to move extracted package: {}", e))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_package_entry() {
+        let toml_str = r#"
+[package]
+name = "router"
+description = "HTTP router for Forge"
+repository = "https://github.com/user/forge-router"
+
+[[versions]]
+version = "1.0.0"
+url = "https://example.com/router-1.0.0.tar.gz"
+checksum = "sha256:abc123"
+
+[[versions]]
+version = "2.0.0"
+url = "https://example.com/router-2.0.0.tar.gz"
+checksum = "sha256:def456"
+"#;
+        let entry: PackageEntry = toml::from_str(toml_str).unwrap();
+        assert_eq!(entry.package.name, "router");
+        assert_eq!(entry.package.description, "HTTP router for Forge");
+        assert_eq!(entry.versions.len(), 2);
+        assert_eq!(entry.versions[0].version, "1.0.0");
+        assert_eq!(entry.versions[1].version, "2.0.0");
+        assert_eq!(entry.versions[0].checksum, "sha256:abc123");
+    }
+
+    #[test]
+    fn parse_minimal_package_entry() {
+        let toml_str = r#"
+[package]
+name = "utils"
+
+[[versions]]
+version = "0.1.0"
+url = "https://example.com/utils.tar.gz"
+"#;
+        let entry: PackageEntry = toml::from_str(toml_str).unwrap();
+        assert_eq!(entry.package.name, "utils");
+        assert_eq!(entry.package.description, "");
+        assert_eq!(entry.versions.len(), 1);
+        assert_eq!(entry.versions[0].checksum, "");
+    }
+
+    #[test]
+    fn resolve_remote_caret() {
+        let versions = vec![
+            VersionEntry {
+                version: "1.0.0".into(),
+                url: "url1".into(),
+                checksum: String::new(),
+            },
+            VersionEntry {
+                version: "1.5.0".into(),
+                url: "url2".into(),
+                checksum: String::new(),
+            },
+            VersionEntry {
+                version: "2.0.0".into(),
+                url: "url3".into(),
+                checksum: String::new(),
+            },
+        ];
+
+        let req = semver::VersionReq::parse("^1.0").unwrap();
+        let resolved = resolve_remote_version("test", &req, &versions).unwrap();
+        assert_eq!(resolved.version, "1.5.0");
+        assert_eq!(resolved.url, "url2");
+    }
+
+    #[test]
+    fn resolve_remote_no_match() {
+        let versions = vec![VersionEntry {
+            version: "1.0.0".into(),
+            url: "url1".into(),
+            checksum: String::new(),
+        }];
+
+        let req = semver::VersionReq::parse("^3.0").unwrap();
+        let err = resolve_remote_version("test", &req, &versions).unwrap_err();
+        assert!(err.contains("no version of 'test' matches"));
+        assert!(err.contains("1.0.0"));
+    }
+
+    #[test]
+    fn resolve_remote_star() {
+        let versions = vec![
+            VersionEntry {
+                version: "1.0.0".into(),
+                url: "url1".into(),
+                checksum: String::new(),
+            },
+            VersionEntry {
+                version: "3.0.0".into(),
+                url: "url3".into(),
+                checksum: String::new(),
+            },
+        ];
+
+        let resolved =
+            resolve_remote_version("test", &semver::VersionReq::STAR, &versions).unwrap();
+        assert_eq!(resolved.version, "3.0.0");
+    }
+
+    #[test]
+    fn cache_ttl_check() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!("forge-cache-test-{}", unique));
+        std::fs::create_dir_all(&temp).unwrap();
+        let file = temp.join("test.toml");
+
+        // Write a file — should be fresh
+        std::fs::write(&file, "test").unwrap();
+        assert!(is_cache_fresh(&file));
+
+        // Non-existent file — not fresh
+        assert!(!is_cache_fresh(&temp.join("nonexistent")));
+
+        std::fs::remove_dir_all(&temp).unwrap();
+    }
+
+    #[test]
+    fn atomic_write_creates_dirs() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir()
+            .join(format!("forge-atomic-{}", unique))
+            .join("sub")
+            .join("test.txt");
+
+        atomic_write(&path, b"hello").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello");
+
+        // Clean up
+        std::fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -36,8 +37,16 @@ pub fn registry_url() -> String {
 }
 
 /// Get the cache directory for registry data.
+/// Uses $HOME/.forge/cache/registry/ so the cache is shared across projects.
 fn cache_dir() -> PathBuf {
-    PathBuf::from(".forge").join("cache").join("registry")
+    if let Ok(home) = env::var("HOME").or_else(|_| env::var("USERPROFILE")) {
+        PathBuf::from(home)
+            .join(".forge")
+            .join("cache")
+            .join("registry")
+    } else {
+        PathBuf::from(".forge").join("cache").join("registry")
+    }
 }
 
 /// Get the configured cache TTL.
@@ -70,7 +79,7 @@ fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let temp = path.with_extension("tmp");
+    let temp = path.with_extension(format!("tmp.{}", std::process::id()));
     std::fs::write(&temp, content)?;
     std::fs::rename(&temp, path)?;
     Ok(())
@@ -219,9 +228,31 @@ pub fn download_to(url: &str, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Verify a file's SHA-256 checksum against an expected value.
+/// Checksum format: "sha256:<hex>" or plain hex.
+pub fn verify_checksum(path: &Path, expected: &str) -> Result<(), String> {
+    let expected_hex = expected.strip_prefix("sha256:").unwrap_or(expected);
+
+    let data =
+        std::fs::read(path).map_err(|e| format!("failed to read file for checksum: {}", e))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let actual_hex = format!("{:x}", hasher.finalize());
+
+    if actual_hex != expected_hex {
+        return Err(format!(
+            "checksum mismatch: expected {}, got {}",
+            expected_hex, actual_hex
+        ));
+    }
+    Ok(())
+}
+
 /// Download a tarball and extract it to a destination directory.
 /// Handles GitHub-style archives that contain a single root directory.
-pub fn download_and_extract(url: &str, dest: &Path) -> Result<(), String> {
+/// Validates tar entries to prevent path traversal attacks.
+pub fn download_and_extract(url: &str, dest: &Path, checksum: &str) -> Result<(), String> {
     let temp_dir = dest.with_extension("extracting");
     if temp_dir.exists() {
         std::fs::remove_dir_all(&temp_dir)
@@ -231,7 +262,12 @@ pub fn download_and_extract(url: &str, dest: &Path) -> Result<(), String> {
     let temp_archive = dest.with_extension("tar.gz");
     download_to(url, &temp_archive)?;
 
-    // Extract the archive
+    // Verify checksum if provided
+    if !checksum.is_empty() {
+        verify_checksum(&temp_archive, checksum)?;
+    }
+
+    // Extract the archive with path traversal protection
     let file =
         std::fs::File::open(&temp_archive).map_err(|e| format!("failed to open archive: {}", e))?;
     let decoder = flate2::read::GzDecoder::new(file);
@@ -239,9 +275,27 @@ pub fn download_and_extract(url: &str, dest: &Path) -> Result<(), String> {
 
     std::fs::create_dir_all(&temp_dir).map_err(|e| format!("failed to create temp dir: {}", e))?;
 
-    archive
-        .unpack(&temp_dir)
-        .map_err(|e| format!("failed to extract archive: {}", e))?;
+    // Validate each entry path before extracting
+    for entry in archive
+        .entries()
+        .map_err(|e| format!("failed to read archive entries: {}", e))?
+    {
+        let mut entry = entry.map_err(|e| format!("corrupt archive entry: {}", e))?;
+        let path = entry
+            .path()
+            .map_err(|e| format!("invalid entry path: {}", e))?;
+
+        // Reject absolute paths and path traversal
+        let path_str = path.to_string_lossy().to_string();
+        if path.is_absolute() || path_str.contains("..") {
+            return Err(format!("archive contains unsafe path: {}", path_str));
+        }
+        drop(path);
+
+        entry
+            .unpack_in(&temp_dir)
+            .map_err(|e| format!("failed to extract '{}': {}", path_str, e))?;
+    }
 
     // Clean up the archive
     let _ = std::fs::remove_file(&temp_archive);
@@ -420,5 +474,47 @@ url = "https://example.com/utils.tar.gz"
 
         // Clean up
         std::fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn checksum_verification_pass() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("forge-checksum-{}", unique));
+        std::fs::write(&path, b"hello world").unwrap();
+
+        // SHA-256 of "hello world"
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        verify_checksum(&path, expected).unwrap();
+
+        // Also works without prefix
+        verify_checksum(
+            &path,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        )
+        .unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn checksum_verification_fail() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("forge-checksum-fail-{}", unique));
+        std::fs::write(&path, b"hello world").unwrap();
+
+        let err = verify_checksum(&path, "sha256:0000000000000000").unwrap_err();
+        assert!(err.contains("checksum mismatch"));
+
+        std::fs::remove_file(&path).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Adds `src/registry.rs` module with remote package index support
- TOML-based package entries with name, description, repository, and versioned download URLs
- Fetches from `raw.githubusercontent.com` with optional `GITHUB_TOKEN` auth for rate limits
- Local cache at `.forge/cache/registry/` with 1-hour TTL (configurable via `FORGE_CACHE_TTL`)
- Atomic file writes (temp + rename) for cache and downloads
- Tarball download and extraction with GitHub archive flattening
- `install_from_registry_as()` now falls back to remote registry when local lookup fails
- Adds `tar` crate and `blocking` feature to reqwest

Roadmap item: 10B.1

## Test plan

- [x] Parse package entry TOML (full and minimal)
- [x] Semver resolution against remote version list (caret, no-match, star)
- [x] Cache TTL freshness check
- [x] Atomic write creates parent directories
- [x] Full test suite passes (1077 tests)