### PR TITLE
feat: forge search command for package registry

### DIFF
--- a/.planning/forge-search.plan.md
+++ b/.planning/forge-search.plan.md
@@ -1,0 +1,55 @@
+# Plan: 10B.2 — `forge search <query>`
+
+## Goal
+
+Add `forge search <query>` command to search the remote package index by name/description.
+
+## Design
+
+### Index File
+
+The registry repo has an `index.toml` file listing all packages:
+
+```toml
+[[packages]]
+name = "router"
+description = "HTTP router for Forge"
+latest = "2.0.0"
+
+[[packages]]
+name = "auth"
+description = "JWT authentication library"
+latest = "1.0.0"
+```
+
+### Implementation
+
+1. Add `PackageSummary { name, description, latest }` to `registry.rs`
+2. Add `fetch_index() -> Result<Vec<PackageSummary>, String>` — fetches `index.toml` from registry, caches locally
+3. Add `search_packages(query, index) -> Vec<PackageSummary>` — filter by case-insensitive substring match on name or description
+4. Add `Search { query: String }` variant to CLI `Command` enum in `main.rs`
+5. Add handler that fetches index, searches, and prints results in a table format
+
+### Files to touch
+
+1. **`src/registry.rs`** — add PackageSummary, fetch_index(), search_packages()
+2. **`src/main.rs`** — add Search subcommand and handler
+
+### Edge cases
+
+- No results → "No packages found matching '<query>'"
+- Empty query → list all packages
+- Network error → clear error message
+- No registry → error with setup hint
+
+## Test strategy
+
+- search_packages() with matching name
+- search_packages() with matching description
+- search_packages() case insensitive
+- search_packages() no match
+- search_packages() empty query returns all
+
+## Rollback
+
+Revert changes to `src/registry.rs` and `src/main.rs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Semver resolution algorithm** — `forge install` now resolves the latest compatible version from the registry instead of requiring exact version matches. Includes directory traversal protection and helpful error messages listing available versions. ([#76](https://github.com/humancto/forge-lang/pull/76))
 - **Transitive dependency resolution** — `forge install` now recursively resolves and installs transitive dependencies from `forge.toml`. Detects circular dependencies and handles diamond dependency patterns. ([#77](https://github.com/humancto/forge-lang/pull/77))
 - **GitHub-based remote package registry** — `forge install` now falls back to a remote GitHub-based package index when local registry lookup fails. Supports TOML-based package entries, semver resolution, tarball download/extraction, local caching with TTL, and `GITHUB_TOKEN` authentication. ([#78](https://github.com/humancto/forge-lang/pull/78))
+- **`forge search <query>`** — search the remote package registry by name or description. Case-insensitive substring matching with cached index. ([#79](https://github.com/humancto/forge-lang/pull/79))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,11 @@ enum Command {
         #[arg(long)]
         registry: Option<String>,
     },
+    /// Search the package registry
+    Search {
+        /// Search query (matches name and description)
+        query: Option<String>,
+    },
     /// Start the Language Server Protocol server
     Lsp,
     /// Start the Debug Adapter Protocol server
@@ -325,6 +330,40 @@ async fn main() {
         }
         Some(Command::Publish { dry_run, registry }) => {
             publish::publish(dry_run, registry.as_deref());
+        }
+        Some(Command::Search { query }) => {
+            let q = query.as_deref().unwrap_or("");
+            match registry::fetch_index() {
+                Ok(index) => {
+                    let results = registry::search_packages(q, &index);
+                    if results.is_empty() {
+                        if q.is_empty() {
+                            println!("No packages found in registry.");
+                        } else {
+                            println!("No packages found matching '{}'.", q);
+                        }
+                    } else {
+                        println!(
+                            "{:<20} {:<10} {}",
+                            "NAME", "VERSION", "DESCRIPTION"
+                        );
+                        println!("{}", "-".repeat(60));
+                        for pkg in &results {
+                            println!(
+                                "{:<20} {:<10} {}",
+                                pkg.name,
+                                if pkg.latest.is_empty() { "-" } else { &pkg.latest },
+                                pkg.description
+                            );
+                        }
+                        println!("\n{} package(s) found.", results.len());
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         Some(Command::Lsp) => {
             lsp::run_lsp();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -31,6 +31,21 @@ pub struct VersionEntry {
     pub checksum: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PackageIndex {
+    #[serde(default)]
+    pub packages: Vec<PackageSummary>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PackageSummary {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub latest: String,
+}
+
 /// Get the configured registry base URL.
 pub fn registry_url() -> String {
     env::var("FORGE_REGISTRY_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_URL.to_string())
@@ -147,6 +162,87 @@ pub fn fetch_package_entry(name: &str) -> Result<Option<PackageEntry>, String> {
     }
 
     Ok(Some(entry))
+}
+
+/// Fetch the package index from the remote registry.
+/// Lists all available packages with name, description, and latest version.
+/// Uses local cache when fresh.
+pub fn fetch_index() -> Result<PackageIndex, String> {
+    let cache_path = cache_dir().join("index.toml");
+
+    // Check cache first
+    if is_cache_fresh(&cache_path) {
+        let content = std::fs::read_to_string(&cache_path)
+            .map_err(|e| format!("failed to read cached index: {}", e))?;
+        let index: PackageIndex =
+            toml::from_str(&content).map_err(|e| format!("corrupt cached index: {}", e))?;
+        return Ok(index);
+    }
+
+    let base_url = registry_url();
+    let url = format!("{}/index.toml", base_url);
+
+    let mut builder = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("failed to create HTTP client: {}", e))?
+        .get(&url);
+
+    if let Ok(token) = env::var("GITHUB_TOKEN") {
+        builder = builder.header("Authorization", format!("token {}", token));
+    }
+
+    let response = match builder.send() {
+        Ok(r) => r,
+        Err(e) => {
+            // If we have a stale cache, use it on network failure
+            if cache_path.exists() {
+                eprintln!(
+                    "  Warning: failed to fetch index, using cached version: {}",
+                    e
+                );
+                let content = std::fs::read_to_string(&cache_path)
+                    .map_err(|e| format!("failed to read cached index: {}", e))?;
+                return toml::from_str(&content)
+                    .map_err(|e| format!("corrupt cached index: {}", e));
+            }
+            return Err(format!("failed to fetch package index: {}", e));
+        }
+    };
+
+    if !response.status().is_success() {
+        return Err(format!("registry returned {} for index", response.status()));
+    }
+
+    let body = response
+        .text()
+        .map_err(|e| format!("failed to read index response: {}", e))?;
+
+    let index: PackageIndex =
+        toml::from_str(&body).map_err(|e| format!("invalid package index: {}", e))?;
+
+    if let Err(e) = atomic_write(&cache_path, body.as_bytes()) {
+        eprintln!("  Warning: failed to cache index: {}", e);
+    }
+
+    Ok(index)
+}
+
+/// Search packages by case-insensitive substring match on name or description.
+/// Empty query returns all packages.
+pub fn search_packages<'a>(query: &str, index: &'a PackageIndex) -> Vec<&'a PackageSummary> {
+    let query_lower = query.to_lowercase();
+    index
+        .packages
+        .iter()
+        .filter(|p| {
+            if query_lower.is_empty() {
+                return true;
+            }
+            p.name.to_lowercase().contains(&query_lower)
+                || p.description.to_lowercase().contains(&query_lower)
+        })
+        .collect()
 }
 
 /// Resolve the best version from a list of version entries using semver.
@@ -516,5 +612,93 @@ url = "https://example.com/utils.tar.gz"
         assert!(err.contains("checksum mismatch"));
 
         std::fs::remove_file(&path).unwrap();
+    }
+
+    fn test_index() -> PackageIndex {
+        PackageIndex {
+            packages: vec![
+                PackageSummary {
+                    name: "router".into(),
+                    description: "HTTP router for Forge".into(),
+                    latest: "2.0.0".into(),
+                },
+                PackageSummary {
+                    name: "auth".into(),
+                    description: "JWT authentication library".into(),
+                    latest: "1.0.0".into(),
+                },
+                PackageSummary {
+                    name: "csv-utils".into(),
+                    description: "CSV parsing utilities".into(),
+                    latest: "0.5.0".into(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn search_by_name() {
+        let index = test_index();
+        let results = search_packages("router", &index);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "router");
+    }
+
+    #[test]
+    fn search_by_description() {
+        let index = test_index();
+        let results = search_packages("JWT", &index);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "auth");
+    }
+
+    #[test]
+    fn search_case_insensitive() {
+        let index = test_index();
+        let results = search_packages("ROUTER", &index);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "router");
+    }
+
+    #[test]
+    fn search_no_match() {
+        let index = test_index();
+        let results = search_packages("nonexistent", &index);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn search_empty_query_returns_all() {
+        let index = test_index();
+        let results = search_packages("", &index);
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn search_partial_match() {
+        let index = test_index();
+        // "csv" matches name "csv-utils" and description "CSV parsing utilities"
+        let results = search_packages("csv", &index);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "csv-utils");
+    }
+
+    #[test]
+    fn parse_package_index() {
+        let toml_str = r#"
+[[packages]]
+name = "router"
+description = "HTTP router"
+latest = "1.0.0"
+
+[[packages]]
+name = "auth"
+description = "Auth library"
+latest = "2.0.0"
+"#;
+        let index: PackageIndex = toml::from_str(toml_str).unwrap();
+        assert_eq!(index.packages.len(), 2);
+        assert_eq!(index.packages[0].name, "router");
+        assert_eq!(index.packages[1].latest, "2.0.0");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `forge search <query>` CLI command to search the remote package index
- Fetches and caches `index.toml` from the registry with same TTL/cache strategy as package entries
- Case-insensitive substring matching on name and description
- Empty query lists all packages
- Graceful fallback to stale cache on network failure
- Table-formatted output with name, version, and description columns

Roadmap item: 10B.2

## Test plan

- [x] Search by name, description, case-insensitive, partial match
- [x] No match returns empty, empty query returns all
- [x] Parse package index TOML
- [x] Full test suite passes (1086 tests)