### PR TITLE
feat: forge add command for dependency management

### DIFF
--- a/.planning/forge-add.plan.md
+++ b/.planning/forge-add.plan.md
@@ -1,0 +1,62 @@
+# Plan: 10C.1 — `forge add <pkg>`
+
+## Goal
+
+Add `forge add <pkg>` command that adds a dependency to `forge.toml` and installs it.
+
+## Design
+
+`forge add router` should:
+
+1. Load (or create) `forge.toml`
+2. Add `router = "*"` to `[dependencies]`
+3. Run `forge install` to resolve and install
+
+`forge add router@^1.0` should add `router = "^1.0"`.
+
+### Implementation
+
+1. Add `Add { package: String }` variant to CLI `Command` enum
+2. Parse `<name>` or `<name>@<version>` format
+3. Load manifest from `forge.toml` (create minimal one if missing)
+4. Add/update the dependency in `[dependencies]`
+5. Write back the updated `forge.toml` (preserve existing content)
+6. Run `install_from_manifest()` to install
+
+### Manifest writing approach
+
+Use `toml_edit` crate for preserving formatting and comments. If not available, use a simple approach: read the file, parse as `toml_edit::Document`, add the dep, serialize back.
+
+Actually, `toml_edit` is not in Cargo.toml. Simpler approach: read the raw TOML, use string manipulation to add/update the `[dependencies]` section, avoiding a full rewrite that loses comments.
+
+Even simpler: since `forge.toml` is a project config (not user-maintained config with lots of comments), we can:
+
+1. Parse with `toml::from_str`
+2. Add the dep
+3. Serialize with `toml::to_string_pretty`
+
+This loses comments but is acceptable for a v1.
+
+### Files to touch
+
+1. **`src/main.rs`** — add Add subcommand and handler
+2. **`src/manifest.rs`** — add `save_manifest()` function
+3. **`src/package.rs`** — already has `install_from_manifest()`
+
+### Edge cases
+
+- No `forge.toml` → create minimal one
+- Package already in deps → update version
+- Invalid package name → error
+- `@` in version spec → parse correctly
+
+## Test strategy
+
+- Parse `name@version` format
+- Parse `name` (no version = "\*")
+- save_manifest round-trip preserves deps
+- Adding to existing manifest with deps
+
+## Rollback
+
+Revert changes to `src/main.rs`, `src/manifest.rs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Transitive dependency resolution** — `forge install` now recursively resolves and installs transitive dependencies from `forge.toml`. Detects circular dependencies and handles diamond dependency patterns. ([#77](https://github.com/humancto/forge-lang/pull/77))
 - **GitHub-based remote package registry** — `forge install` now falls back to a remote GitHub-based package index when local registry lookup fails. Supports TOML-based package entries, semver resolution, tarball download/extraction, local caching with TTL, and `GITHUB_TOKEN` authentication. ([#78](https://github.com/humancto/forge-lang/pull/78))
 - **`forge search <query>`** — search the remote package registry by name or description. Case-insensitive substring matching with cached index. ([#79](https://github.com/humancto/forge-lang/pull/79))
+- **`forge add <pkg>`** — add a dependency to `forge.toml` and install it. Supports `forge add router` (any version) and `forge add router@^1.0` (with constraint). ([#80](https://github.com/humancto/forge-lang/pull/80))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,11 @@ enum Command {
         /// Git URL or local path
         source: String,
     },
+    /// Add a dependency to forge.toml and install it
+    Add {
+        /// Package name or name@version (e.g., "router" or "router@^1.0")
+        package: String,
+    },
     /// Publish the current project to the local registry
     Publish {
         /// Show what would be packaged without publishing
@@ -327,6 +332,33 @@ async fn main() {
         }
         Some(Command::Install { source }) => {
             package::install(&source);
+        }
+        Some(Command::Add { package: pkg }) => {
+            match manifest::parse_package_spec(&pkg) {
+                Ok((name, version)) => {
+                    let mut m = manifest::load_manifest().unwrap_or_default();
+                    let action = if m.dependencies.contains_key(&name) {
+                        "Updated"
+                    } else {
+                        "Added"
+                    };
+                    m.dependencies
+                        .insert(name.clone(), manifest::DependencySpec::Version(version.clone()));
+                    if let Err(e) = manifest::save_manifest(&m) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                    println!(
+                        "  {} {} = \"{}\" to forge.toml",
+                        action, name, version
+                    );
+                    package::install_from_manifest();
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         Some(Command::Publish { dry_run, registry }) => {
             publish::publish(dry_run, registry.as_deref());

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -159,6 +159,35 @@ pub fn load_manifest_from(path: &Path) -> Option<Manifest> {
     toml::from_str(&content).ok()
 }
 
+pub fn save_manifest(manifest: &Manifest) -> Result<(), String> {
+    save_manifest_to(manifest, Path::new("forge.toml"))
+}
+
+pub fn save_manifest_to(manifest: &Manifest, path: &Path) -> Result<(), String> {
+    let content = toml::to_string_pretty(manifest)
+        .map_err(|e| format!("failed to serialize manifest: {}", e))?;
+    std::fs::write(path, content).map_err(|e| format!("failed to write {}: {}", path.display(), e))
+}
+
+/// Parse a package spec like "name" or "name@^1.0" into (name, version).
+pub fn parse_package_spec(spec: &str) -> Result<(String, String), String> {
+    if spec.is_empty() {
+        return Err("package name cannot be empty".to_string());
+    }
+
+    if let Some((name, version)) = spec.split_once('@') {
+        if name.is_empty() {
+            return Err("package name cannot be empty".to_string());
+        }
+        if version.is_empty() {
+            return Err("version constraint cannot be empty after '@'".to_string());
+        }
+        Ok((name.to_string(), version.to_string()))
+    } else {
+        Ok((spec.to_string(), "*".to_string()))
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Lockfile {
     pub packages: Vec<LockedPackage>,
@@ -431,5 +460,68 @@ test = "forge test"
         let v300 = semver::Version::parse("3.0.0").unwrap();
         assert!(dep.matches_version(&v210).unwrap());
         assert!(!dep.matches_version(&v300).unwrap());
+    }
+
+    #[test]
+    fn parse_package_spec_name_only() {
+        let (name, version) = parse_package_spec("router").unwrap();
+        assert_eq!(name, "router");
+        assert_eq!(version, "*");
+    }
+
+    #[test]
+    fn parse_package_spec_with_version() {
+        let (name, version) = parse_package_spec("router@^1.0").unwrap();
+        assert_eq!(name, "router");
+        assert_eq!(version, "^1.0");
+    }
+
+    #[test]
+    fn parse_package_spec_exact_version() {
+        let (name, version) = parse_package_spec("utils@1.2.3").unwrap();
+        assert_eq!(name, "utils");
+        assert_eq!(version, "1.2.3");
+    }
+
+    #[test]
+    fn parse_package_spec_empty() {
+        assert!(parse_package_spec("").is_err());
+    }
+
+    #[test]
+    fn parse_package_spec_empty_name() {
+        assert!(parse_package_spec("@1.0").is_err());
+    }
+
+    #[test]
+    fn parse_package_spec_empty_version() {
+        assert!(parse_package_spec("router@").is_err());
+    }
+
+    #[test]
+    fn save_manifest_round_trip() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("forge-manifest-{}.toml", unique));
+
+        let mut manifest = Manifest::default();
+        manifest.project.name = "test-app".to_string();
+        manifest.dependencies.insert(
+            "router".to_string(),
+            DependencySpec::Version("^1.0".to_string()),
+        );
+
+        save_manifest_to(&manifest, &path).unwrap();
+
+        let loaded = load_manifest_from(&path).unwrap();
+        assert_eq!(loaded.project.name, "test-app");
+        assert_eq!(loaded.dependencies.len(), 1);
+        assert_eq!(loaded.dependencies["router"].version_str(), "^1.0");
+
+        std::fs::remove_file(&path).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Adds `forge add <pkg>` CLI command that adds a dependency to `forge.toml` and installs it
- Supports `forge add router` (adds as `"*"`) and `forge add router@^1.0` (with version constraint)
- Updates existing dependency version if package already listed
- Creates minimal `forge.toml` if none exists
- Adds `save_manifest()`, `save_manifest_to()`, and `parse_package_spec()` to manifest.rs

Roadmap item: 10C.1

## Test plan

- [x] Parse name-only, name@version, exact version, empty cases
- [x] Save manifest round-trip preserves data
- [x] Full test suite passes (1093 tests)