### PR TITLE
feat: intern strings in GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`forge add <pkg>`** — add a dependency to `forge.toml` and install it. Supports `forge add router` (any version) and `forge add router@^1.0` (with constraint). ([#80](https://github.com/humancto/forge-lang/pull/80))
 - **`forge update`** — update all dependencies to latest compatible versions by re-resolving from registries. ([#81](https://github.com/humancto/forge-lang/pull/81))
 - **Lockfile integrity checking** — `forge install` computes directory-content SHA-256 checksums and stores them in `forge.lock`. On subsequent installs, verifies installed packages haven't been tampered with. Backwards-compatible with existing lockfiles via `checksum_kind` field. ([#82](https://github.com/humancto/forge-lang/pull/82))
+- **String interning in GC** — identical strings (≤128 bytes) are deduplicated via hash-consing in the garbage collector. Reduces memory usage for programs with repeated string values. ([#83](https://github.com/humancto/forge-lang/pull/83))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/gc.rs
+++ b/src/vm/gc.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+
 use super::value::{GcObject, GcRef, ObjKind, Value};
 
 const INITIAL_GC_THRESHOLD: usize = 8192;
 const GC_GROWTH_FACTOR: usize = 2;
+/// Strings longer than this are not interned (avoids bloating the table with
+/// large unique strings like HTTP bodies or file contents).
+const INTERN_MAX_LEN: usize = 128;
 
 /// Mark-sweep garbage collector.
 pub struct Gc {
@@ -9,6 +14,8 @@ pub struct Gc {
     free_list: Vec<usize>,
     pub alloc_count: usize,
     next_gc: usize,
+    /// Intern table: maps string content → canonical GcRef.
+    interned: HashMap<String, GcRef>,
 }
 
 impl Gc {
@@ -18,6 +25,7 @@ impl Gc {
             free_list: Vec::new(),
             alloc_count: 0,
             next_gc: INITIAL_GC_THRESHOLD,
+            interned: HashMap::new(),
         }
     }
 
@@ -35,9 +43,20 @@ impl Gc {
         }
     }
 
-    /// Allocate a string and return its GcRef.
+    /// Allocate a string, interning short strings for deduplication.
+    /// Strings ≤ INTERN_MAX_LEN bytes are looked up in the intern table first;
+    /// if already present, the existing GcRef is returned (no new allocation).
     pub fn alloc_string(&mut self, s: String) -> GcRef {
-        self.alloc(ObjKind::String(s))
+        if s.len() <= INTERN_MAX_LEN {
+            if let Some(&existing) = self.interned.get(&s) {
+                return existing;
+            }
+            let r = self.alloc(ObjKind::String(s.clone()));
+            self.interned.insert(s, r);
+            r
+        } else {
+            self.alloc(ObjKind::String(s))
+        }
     }
 
     /// Check if GC should run.
@@ -83,14 +102,24 @@ impl Gc {
     fn sweep(&mut self) {
         let mut freed = 0;
         for i in 0..self.objects.len() {
-            if let Some(obj) = &mut self.objects[i] {
-                if obj.marked {
-                    obj.marked = false;
-                } else {
-                    self.objects[i] = None;
-                    self.free_list.push(i);
-                    freed += 1;
+            let should_free = match &self.objects[i] {
+                Some(obj) => !obj.marked,
+                None => false,
+            };
+            if should_free {
+                // Extract string content before destroying, to clean intern table
+                if let Some(obj) = &self.objects[i] {
+                    if let ObjKind::String(ref s) = obj.kind {
+                        if s.len() <= INTERN_MAX_LEN {
+                            self.interned.remove(s);
+                        }
+                    }
                 }
+                self.objects[i] = None;
+                self.free_list.push(i);
+                freed += 1;
+            } else if let Some(obj) = &mut self.objects[i] {
+                obj.marked = false;
             }
         }
         self.alloc_count = self.alloc_count.saturating_sub(freed);
@@ -109,5 +138,105 @@ impl Gc {
                 }
             })
             .collect()
+    }
+
+    /// Number of entries in the intern table (for testing).
+    #[cfg(test)]
+    pub fn intern_count(&self) -> usize {
+        self.interned.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interned_strings_share_gcref() {
+        let mut gc = Gc::new();
+        let r1 = gc.alloc_string("hello".to_string());
+        let r2 = gc.alloc_string("hello".to_string());
+        assert_eq!(r1, r2, "same string should return same GcRef");
+    }
+
+    #[test]
+    fn different_strings_get_different_refs() {
+        let mut gc = Gc::new();
+        let r1 = gc.alloc_string("hello".to_string());
+        let r2 = gc.alloc_string("world".to_string());
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn long_strings_not_interned() {
+        let mut gc = Gc::new();
+        let long = "x".repeat(INTERN_MAX_LEN + 1);
+        let r1 = gc.alloc_string(long.clone());
+        let r2 = gc.alloc_string(long);
+        assert_ne!(r1, r2, "long strings should not be interned");
+    }
+
+    #[test]
+    fn short_strings_at_boundary_are_interned() {
+        let mut gc = Gc::new();
+        let at_limit = "x".repeat(INTERN_MAX_LEN);
+        let r1 = gc.alloc_string(at_limit.clone());
+        let r2 = gc.alloc_string(at_limit);
+        assert_eq!(r1, r2, "string at exact limit should be interned");
+    }
+
+    #[test]
+    fn sweep_removes_unreachable_interned_strings() {
+        let mut gc = Gc::new();
+        let _r1 = gc.alloc_string("ephemeral".to_string());
+        assert_eq!(gc.intern_count(), 1);
+
+        // Collect with no roots — everything is unreachable
+        gc.collect(&[]);
+        assert_eq!(
+            gc.intern_count(),
+            0,
+            "intern table should be cleaned on sweep"
+        );
+    }
+
+    #[test]
+    fn sweep_keeps_reachable_interned_strings() {
+        let mut gc = Gc::new();
+        let r1 = gc.alloc_string("keep".to_string());
+        let _r2 = gc.alloc_string("discard".to_string());
+        assert_eq!(gc.intern_count(), 2);
+
+        // Only r1 is a root
+        gc.collect(&[r1]);
+        assert_eq!(gc.intern_count(), 1);
+
+        // The kept ref is still valid and interned
+        let r3 = gc.alloc_string("keep".to_string());
+        assert_eq!(r1, r3, "surviving interned string should be reused");
+    }
+
+    #[test]
+    fn re_interning_after_collection() {
+        let mut gc = Gc::new();
+        let r1 = gc.alloc_string("temp".to_string());
+        gc.collect(&[]); // sweep removes it
+        assert_eq!(gc.intern_count(), 0);
+
+        // Re-allocating the same string should work (new slot)
+        let r2 = gc.alloc_string("temp".to_string());
+        assert_eq!(gc.intern_count(), 1);
+        // May or may not reuse the same index (free list), but ref should be valid
+        assert!(gc.get(r2).is_some());
+        // r1 should be invalid (freed)
+        let _ = r1; // just to suppress unused warning
+    }
+
+    #[test]
+    fn empty_string_is_interned() {
+        let mut gc = Gc::new();
+        let r1 = gc.alloc_string(String::new());
+        let r2 = gc.alloc_string(String::new());
+        assert_eq!(r1, r2);
     }
 }


### PR DESCRIPTION
## Summary

- Adds string interning (hash-consing) to the GC for strings ≤128 bytes
- Duplicate `alloc_string()` calls return existing `GcRef` — no new allocation
- Sweep phase cleans intern table entries for freed strings
- Long strings (>128 bytes) bypass interning to avoid table bloat from HTTP bodies, file contents, etc.

Roadmap item: **11A.1**

## Test plan

- [x] `interned_strings_share_gcref` — same string returns same ref
- [x] `different_strings_get_different_refs`
- [x] `long_strings_not_interned` — strings >128 bytes get separate allocations
- [x] `short_strings_at_boundary_are_interned` — exact 128 bytes is interned
- [x] `sweep_removes_unreachable_interned_strings`
- [x] `sweep_keeps_reachable_interned_strings`
- [x] `re_interning_after_collection` — re-alloc after sweep works
- [x] `empty_string_is_interned`
- [x] All 1109 existing tests pass