### PR TITLE
feat: interned string fast equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`forge update`** — update all dependencies to latest compatible versions by re-resolving from registries. ([#81](https://github.com/humancto/forge-lang/pull/81))
 - **Lockfile integrity checking** — `forge install` computes directory-content SHA-256 checksums and stores them in `forge.lock`. On subsequent installs, verifies installed packages haven't been tampered with. Backwards-compatible with existing lockfiles via `checksum_kind` field. ([#82](https://github.com/humancto/forge-lang/pull/82))
 - **String interning in GC** — identical strings (≤128 bytes) are deduplicated via hash-consing in the garbage collector. Reduces memory usage for programs with repeated string values. ([#83](https://github.com/humancto/forge-lang/pull/83))
+- **Interned string fast equality** — `==` on interned strings short-circuits via GcRef pointer comparison, skipping byte-by-byte comparison. ([#84](https://github.com/humancto/forge-lang/pull/84))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -180,10 +180,16 @@ impl Value {
             (Value::Float(a), Value::Int(b)) => *a == (*b as f64),
             (Value::Bool(a), Value::Bool(b)) => a == b,
             (Value::Null, Value::Null) => true,
-            (Value::Obj(a), Value::Obj(b)) => match (gc.get(*a), gc.get(*b)) {
-                (Some(oa), Some(ob)) => oa.equals(ob, gc),
-                _ => false,
-            },
+            (Value::Obj(a), Value::Obj(b)) => {
+                // Fast path: interned strings (and any shared object) have the same GcRef
+                if a == b {
+                    return true;
+                }
+                match (gc.get(*a), gc.get(*b)) {
+                    (Some(oa), Some(ob)) => oa.equals(ob, gc),
+                    _ => false,
+                }
+            }
             _ => false,
         }
     }

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -181,7 +181,9 @@ impl Value {
             (Value::Bool(a), Value::Bool(b)) => a == b,
             (Value::Null, Value::Null) => true,
             (Value::Obj(a), Value::Obj(b)) => {
-                // Fast path: interned strings (and any shared object) have the same GcRef
+                // Fast path: two live refs with the same arena index are the same
+                // allocation. No ObjKind variant wraps floats (those use Value::Float),
+                // so NaN self-inequality is not a concern.
                 if a == b {
                     return true;
                 }


### PR DESCRIPTION
## Summary

- Adds GcRef pointer comparison fast path in `Value::equals()`
- When two `Value::Obj` refs point to the same GcRef, returns `true` immediately
- Interned strings (from 11A.1) automatically benefit — no byte-by-byte comparison needed
- Non-interned strings and different objects fall through to existing deep comparison

Roadmap item: **11A.2**

## Test plan

- [x] All 1109 existing tests pass (transparent optimization)
- Pure performance optimization — no behavioral change