### PR TITLE
perf: intern field name lookups in GetField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lockfile integrity checking** — `forge install` computes directory-content SHA-256 checksums and stores them in `forge.lock`. On subsequent installs, verifies installed packages haven't been tampered with. Backwards-compatible with existing lockfiles via `checksum_kind` field. ([#82](https://github.com/humancto/forge-lang/pull/82))
 - **String interning in GC** — identical strings (≤128 bytes) are deduplicated via hash-consing in the garbage collector. Reduces memory usage for programs with repeated string values. ([#83](https://github.com/humancto/forge-lang/pull/83))
 - **Interned string fast equality** — `==` on interned strings short-circuits via GcRef pointer comparison, skipping byte-by-byte comparison. ([#84](https://github.com/humancto/forge-lang/pull/84))
+- **Interned field name lookups** — `GetField` opcode avoids cloning field name strings from the constant pool, using `&str` references directly for object map lookups. ([#85](https://github.com/humancto/forge-lang/pull/85))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1450,13 +1450,12 @@ impl VM {
                         let field_const = &chunk.constants[c as usize];
                         if let (Value::Obj(r), Constant::Str(field)) = (obj_val, field_const) {
                             let r = *r;
-                            let field = field.clone();
                             let needs_alloc: Option<String>;
                             let direct_result: Option<Value>;
                             if let Some(obj) = self.gc.get(r) {
                                 match &obj.kind {
                                     ObjKind::Object(map) => {
-                                        if let Some(value) = map.get(&field).cloned() {
+                                        if let Some(value) = map.get(field.as_str()).cloned() {
                                             direct_result = Some(value);
                                         } else if let Some(type_name) = map
                                             .get("__type__")
@@ -1481,7 +1480,9 @@ impl VM {
                                                     else {
                                                         continue;
                                                     };
-                                                    if let Some(value) = embed_map.get(&field) {
+                                                    if let Some(value) =
+                                                        embed_map.get(field.as_str())
+                                                    {
                                                         delegated = Some(*value);
                                                         break;
                                                     }
@@ -1494,14 +1495,15 @@ impl VM {
                                                 ))
                                             })?);
                                         } else {
-                                            direct_result = Some(
-                                                map.get(&field).cloned().ok_or_else(|| {
-                                                    VMError::new(&format!(
-                                                        "no field '{}' on object",
-                                                        field
-                                                    ))
-                                                })?,
-                                            );
+                                            direct_result =
+                                                Some(map.get(field.as_str()).cloned().ok_or_else(
+                                                    || {
+                                                        VMError::new(&format!(
+                                                            "no field '{}' on object",
+                                                            field
+                                                        ))
+                                                    },
+                                                )?);
                                         }
                                         needs_alloc = None;
                                     }


### PR DESCRIPTION
## Summary

- Eliminates `String::clone()` of field names from the constant pool in `GetField` opcode
- Uses `&str` references directly for `IndexMap` lookups via `field.as_str()`
- `SetField` still clones for `insert()` (needs owned key) — this is less hot
- Reduces per-field-access allocation overhead

Roadmap item: **11A.3**

## Test plan

- [x] All 1109 existing tests pass
- Pure performance optimization — no behavioral change