### PR TITLE
feat: VM channel extras — try_send, try_receive, select

### DIFF
--- a/.planning/vm-channel-extras.plan.md
+++ b/.planning/vm-channel-extras.plan.md
@@ -1,0 +1,69 @@
+# Plan: VM Channel Extras
+
+## Goal
+
+Port `try_send()`, `try_receive()`, `select()` builtins from interpreter to VM for full channel API parity.
+
+## Current State
+
+- VM has `channel()`, `send()`, `receive()`, `close()` (PR #87)
+- Interpreter has all 7 channel builtins
+- `try_send`, `try_receive`, `select` missing from VM
+
+## Design
+
+### `try_send(ch, value)` -> Bool
+
+Non-blocking send. Returns `true` on success, `false` if channel full/closed.
+
+- Bounded: use `SyncSender::try_send()` — returns `TrySendError` on full/disconnected
+- Unbounded: use `Sender::send()` (unbounded never blocks) — returns `false` only on disconnect
+
+Matches interpreter: `Ok(()) => Ok(Value::Bool(true))`, `Err(_) => Ok(Value::Bool(false))`.
+
+### `try_receive(ch)` -> Some(value) | None
+
+Non-blocking receive. Returns `Some(value)` if available, `None` if empty/closed.
+
+- Use `Receiver::try_recv()` — returns `TryRecvError` on empty/disconnected
+
+VM difference: interpreter returns `Value::Some(Box::new(val))` / `Value::None`. VM has `ObjKind::ResultOk(v)` / `Value::Null`. Need to check interpreter's `Some`/`None` mapping.
+
+Actually looking at interpreter: `Value::Some(Box::new(val))` and `Value::None`. The VM doesn't have `Value::Some`/`Value::None` — these are interpreter-only types. In VM, we need to match equivalent semantics. The natural VM mapping:
+
+- Success: wrap in `ObjKind::ResultOk(value)` (maps to `Some`)
+- Empty/closed: `Value::Null` (maps to `None`)
+
+This matches how `is_some()`/`is_none()` work in the VM — `is_some` checks `ResultOk`, `is_none` checks Null.
+
+### `select(channels, timeout_ms?)` -> [index, value] | null
+
+Poll multiple channels, return first available message with its channel index.
+
+- Takes array of channels + optional timeout in ms
+- Spin-loop with `try_recv()`, round-robin offset to avoid starvation
+- Returns `[channel_index, received_value]` on success
+- Returns `null` on timeout or all channels closed
+- Sleeps 1ms between polls (matches interpreter)
+
+### Files to touch
+
+1. `src/vm/builtins.rs` — add `try_send`, `try_receive`, `select` handlers
+2. `src/vm/machine.rs` — register the 3 builtins
+3. `src/vm/async_tests.rs` — TDD tests
+
+## Test Strategy (TDD — tests first)
+
+1. `vm_try_send_success` — try_send to buffered channel returns true
+2. `vm_try_send_full` — try_send to full bounded channel returns false
+3. `vm_try_send_closed` — try_send to closed channel returns false
+4. `vm_try_receive_available` — try_receive with pending message returns value
+5. `vm_try_receive_empty` — try_receive on empty channel returns null
+6. `vm_select_single_channel` — select with one channel returns [0, value]
+7. `vm_select_multiple_channels` — select picks the ready channel
+8. `vm_select_timeout` — select with timeout returns null when no messages
+9. `vm_select_all_closed` — select returns null when all channels closed
+
+## Rollback
+
+Revert changes to `builtins.rs`, `machine.rs`, `async_tests.rs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Interned field name lookups** — `GetField` opcode avoids cloning field name strings from the constant pool, using `&str` references directly for object map lookups. ([#85](https://github.com/humancto/forge-lang/pull/85))
 - **JIT string operations** — JIT compiler now supports string concat, length, and equality via runtime bridge calls. Functions with string-only operations (no float mixing) can be JIT-compiled. ([#86](https://github.com/humancto/forge-lang/pull/86))
 - **VM channel builtins** — `channel()`, `send()`, `receive()`, `close()` now work in `--vm` mode. Supports bounded and unbounded channels with cross-spawn communication. ([#87](https://github.com/humancto/forge-lang/pull/87))
+- **VM channel extras** — `try_send()`, `try_receive()`, `select()` now work in `--vm` mode. Non-blocking channel operations and multi-channel select with optional timeout. ([#88](https://github.com/humancto/forge-lang/pull/88))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/async_tests.rs
+++ b/src/vm/async_tests.rs
@@ -296,3 +296,131 @@ fn vm_channel_send_receive_array() {
     );
     assert_eq!(out, vec!["3", "20"]);
 }
+
+// ----- Channel extras: try_send, try_receive, select -----
+
+#[test]
+fn vm_try_send_success() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        println(try_send(ch, 42))
+    "#,
+    );
+    assert_eq!(out, vec!["true"]);
+}
+
+#[test]
+fn vm_try_send_full() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        try_send(ch, 1)
+        println(try_send(ch, 2))
+    "#,
+    );
+    assert_eq!(out, vec!["false"]);
+}
+
+#[test]
+fn vm_try_send_closed() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        close(ch)
+        println(try_send(ch, 1))
+    "#,
+    );
+    assert_eq!(out, vec!["false"]);
+}
+
+#[test]
+fn vm_try_receive_available() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        send(ch, 42)
+        let result = try_receive(ch)
+        println(is_some(result))
+        println(unwrap(result))
+    "#,
+    );
+    assert_eq!(out, vec!["true", "42"]);
+}
+
+#[test]
+fn vm_try_receive_empty() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        let result = try_receive(ch)
+        println(is_none(result))
+    "#,
+    );
+    assert_eq!(out, vec!["true"]);
+}
+
+#[test]
+fn vm_select_single_channel() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        send(ch, "hello")
+        let result = select([ch])
+        println(result[0])
+        println(result[1])
+    "#,
+    );
+    assert_eq!(out, vec!["0", "hello"]);
+}
+
+#[test]
+fn vm_select_multiple_channels() {
+    let out = run_on_vm(
+        r#"
+        let ch1 = channel(1)
+        let ch2 = channel(1)
+        send(ch2, "from-ch2")
+        let result = select([ch1, ch2])
+        println(result[0])
+        println(result[1])
+    "#,
+    );
+    assert_eq!(out, vec!["1", "from-ch2"]);
+}
+
+#[test]
+fn vm_select_timeout() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        let result = select([ch], 10)
+        println(result)
+    "#,
+    );
+    assert_eq!(out, vec!["null"]);
+}
+
+#[test]
+fn vm_select_all_closed() {
+    let out = run_on_vm(
+        r#"
+        let ch = channel(1)
+        close(ch)
+        let result = select([ch])
+        println(result)
+    "#,
+    );
+    assert_eq!(out, vec!["null"]);
+}
+
+#[test]
+fn vm_select_empty_array() {
+    let out = run_on_vm(
+        r#"
+        let result = select([])
+        println(result)
+    "#,
+    );
+    assert_eq!(out, vec!["null"]);
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -2881,6 +2881,110 @@ impl VM {
                 *guard = None;
                 Ok(Value::Null)
             }
+            "try_send" => {
+                if args.len() < 2 {
+                    return Err(VMError::new("try_send() requires (channel, value)"));
+                }
+                let ch_arc = self.extract_channel(&args[0])?;
+                let shared = value_to_shared(&self.gc, &args[1]);
+                let guard = ch_arc.sender.lock().unwrap_or_else(|e| e.into_inner());
+                let ok = match &*guard {
+                    Some(VmChannelSender::Bounded(tx)) => tx.try_send(shared).is_ok(),
+                    // Unbounded send only fails if receiver is dropped
+                    Some(VmChannelSender::Unbounded(tx)) => tx.send(shared).is_ok(),
+                    None => false,
+                };
+                Ok(Value::Bool(ok))
+            }
+            "try_receive" => {
+                if args.is_empty() {
+                    return Err(VMError::new("try_receive() requires (channel)"));
+                }
+                let ch_arc = self.extract_channel(&args[0])?;
+                let guard = ch_arc.receiver.lock().unwrap_or_else(|e| e.into_inner());
+                match &*guard {
+                    Some(rx) => match rx.try_recv() {
+                        Ok(shared) => {
+                            let val = shared_to_value(&mut self.gc, &shared);
+                            let r = self.gc.alloc(ObjKind::ResultOk(val));
+                            Ok(Value::Obj(r))
+                        }
+                        Err(_) => Ok(Value::Null),
+                    },
+                    None => Ok(Value::Null),
+                }
+            }
+            "select" => {
+                if args.is_empty() {
+                    return Err(VMError::new("select() requires an array of channels"));
+                }
+                // Extract channels from the array argument
+                let channels: Vec<Arc<VmChannelInner>> = match &args[0] {
+                    Value::Obj(r) => match self.gc.get(*r) {
+                        Some(obj) => match &obj.kind {
+                            ObjKind::Array(items) => {
+                                let mut chs = Vec::with_capacity(items.len());
+                                for item in items {
+                                    chs.push(self.extract_channel(item)?);
+                                }
+                                chs
+                            }
+                            _ => {
+                                return Err(VMError::new("select() requires an array of channels"))
+                            }
+                        },
+                        None => return Err(VMError::new("select() requires an array of channels")),
+                    },
+                    _ => return Err(VMError::new("select() requires an array of channels")),
+                };
+                if channels.is_empty() {
+                    return Ok(Value::Null);
+                }
+                let timeout_ms: Option<u128> = match args.get(1) {
+                    Some(Value::Int(ms)) => Some((*ms).max(0) as u128),
+                    Some(Value::Float(ms)) => Some(ms.max(0.0) as u128),
+                    _ => None,
+                };
+                let start = std::time::Instant::now();
+                let len = channels.len();
+                let mut offset = 0usize;
+                loop {
+                    let mut all_closed = true;
+                    for i in 0..len {
+                        let idx = (i + offset) % len;
+                        let rx_guard = channels[idx]
+                            .receiver
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner());
+                        if let Some(ref rx) = *rx_guard {
+                            match rx.try_recv() {
+                                Ok(shared) => {
+                                    let val = shared_to_value(&mut self.gc, &shared);
+                                    let idx_val = Value::Int(idx as i64);
+                                    let arr = self.gc.alloc(ObjKind::Array(vec![idx_val, val]));
+                                    return Ok(Value::Obj(arr));
+                                }
+                                Err(std::sync::mpsc::TryRecvError::Empty) => {
+                                    all_closed = false;
+                                }
+                                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                                    // Sender dropped (channel closed) — treat as closed
+                                }
+                            }
+                        }
+                    }
+                    if all_closed {
+                        return Ok(Value::Null);
+                    }
+                    if let Some(ms) = timeout_ms {
+                        if start.elapsed().as_millis() >= ms {
+                            return Ok(Value::Null);
+                        }
+                    }
+                    offset = (offset + 1) % len;
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            }
 
             // Note: lowercase ok/err aliases are handled ABOVE (before "Ok"/"Err") to avoid
             // unreachable pattern warnings. The dead duplicates below have been removed.

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -500,6 +500,9 @@ impl VM {
             "send",
             "receive",
             "close",
+            "try_send",
+            "try_receive",
+            "select",
         ];
         for name in &builtins {
             let name_ref = self.gc.alloc(ObjKind::NativeFunction(NativeFn {


### PR DESCRIPTION
## Summary

- Ports `try_send()`, `try_receive()`, `select()` from interpreter to VM for full channel API parity
- `try_send(ch, val)` — non-blocking send, returns `true`/`false`
- `try_receive(ch)` — non-blocking receive, returns `ResultOk(val)` or `Null` (works with `is_some`/`is_none`/`unwrap`)
- `select([ch1, ch2, ...], timeout_ms?)` — polls channels round-robin, returns `[index, value]` or `null` on timeout/all-closed

Roadmap item: `VM channel extras: try_send(), try_receive(), select()`

## Test plan

- [x] `vm_try_send_success` — bounded channel, returns true
- [x] `vm_try_send_full` — full bounded channel, returns false
- [x] `vm_try_send_closed` — closed channel, returns false
- [x] `vm_try_receive_available` — message pending, returns value
- [x] `vm_try_receive_empty` — empty channel, returns null
- [x] `vm_select_single_channel` — single ready channel, returns [0, val]
- [x] `vm_select_multiple_channels` — picks ready channel (ch2)
- [x] `vm_select_timeout` — no messages, returns null after 10ms
- [x] `vm_select_all_closed` — all closed, returns null immediately
- [x] `vm_select_empty_array` — empty array, returns null immediately
- [x] 1137 total tests pass