### PR TITLE
feat: VM async coordination — await_all, await_timeout

### DIFF
--- a/.planning/vm-async-coordination.plan.md
+++ b/.planning/vm-async-coordination.plan.md
@@ -1,0 +1,43 @@
+# Plan: VM Async Coordination
+
+## Goal
+
+Port `await_all()` and `await_timeout()` builtins from interpreter to VM.
+
+## Design
+
+### `await_all(handles)` -> Array
+
+- Takes array of task handles
+- Iterates each handle, waits on condvar (same as Await opcode)
+- Unwraps ResultOk, propagates ResultErr as VMError
+- Non-task-handle values pass through unchanged
+- Returns array of collected results
+
+### `await_timeout(handle, timeout_ms)` -> value | null
+
+- Takes single task handle + timeout in ms (int or float)
+- Uses `cvar.wait_timeout(guard, Duration::from_millis(ms))`
+- Returns null on timeout
+- Unwraps ResultOk, propagates ResultErr
+
+### Helper method
+
+Extract `extract_task_handle()` similar to `extract_channel()` — returns `Arc<(Mutex<Option<SharedValue>>, Condvar)>`.
+
+### Files
+
+1. `src/vm/builtins.rs` — add `await_all`, `await_timeout` + helper
+2. `src/vm/machine.rs` — register builtins
+3. `src/vm/async_tests.rs` — TDD tests
+
+## Tests
+
+1. `vm_await_all_basic` — await_all with multiple spawn handles
+2. `vm_await_all_mixed` — array with task handles and plain values
+3. `vm_await_timeout_completes` — task finishes within timeout
+4. `vm_await_timeout_expires` — task takes too long, returns null
+
+## Rollback
+
+Revert builtins.rs, machine.rs, async_tests.rs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JIT string operations** — JIT compiler now supports string concat, length, and equality via runtime bridge calls. Functions with string-only operations (no float mixing) can be JIT-compiled. ([#86](https://github.com/humancto/forge-lang/pull/86))
 - **VM channel builtins** — `channel()`, `send()`, `receive()`, `close()` now work in `--vm` mode. Supports bounded and unbounded channels with cross-spawn communication. ([#87](https://github.com/humancto/forge-lang/pull/87))
 - **VM channel extras** — `try_send()`, `try_receive()`, `select()` now work in `--vm` mode. Non-blocking channel operations and multi-channel select with optional timeout. ([#88](https://github.com/humancto/forge-lang/pull/88))
+- **VM async coordination** — `await_all()` and `await_timeout()` now work in `--vm` mode. Await multiple task handles or a single handle with a deadline. ([#89](https://github.com/humancto/forge-lang/pull/89))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/async_tests.rs
+++ b/src/vm/async_tests.rs
@@ -424,3 +424,65 @@ fn vm_select_empty_array() {
     );
     assert_eq!(out, vec!["null"]);
 }
+
+// ----- Async coordination: await_all, await_timeout -----
+
+#[test]
+fn vm_await_all_basic() {
+    let out = run_on_vm(
+        r#"
+        let a = spawn { return 10 }
+        let b = spawn { return 20 }
+        let c = spawn { return 30 }
+        let results = await_all([a, b, c])
+        println(results[0])
+        println(results[1])
+        println(results[2])
+    "#,
+    );
+    assert_eq!(out, vec!["10", "20", "30"]);
+}
+
+#[test]
+fn vm_await_all_empty() {
+    let out = run_on_vm_value("await_all([])");
+    assert_eq!(out, "[]");
+}
+
+#[test]
+fn vm_await_all_mixed() {
+    let out = run_on_vm(
+        r#"
+        let h = spawn { return 42 }
+        let results = await_all([h, 99])
+        println(results[0])
+        println(results[1])
+    "#,
+    );
+    assert_eq!(out, vec!["42", "99"]);
+}
+
+#[test]
+fn vm_await_timeout_completes() {
+    let out = run_on_vm_value(
+        r#"
+        let h = spawn { return 42 }
+        await_timeout(h, 5000)
+    "#,
+    );
+    assert_eq!(out, "42");
+}
+
+#[test]
+fn vm_await_timeout_expires() {
+    let out = run_on_vm_value(
+        r#"
+        let ch = channel()
+        let h = spawn { receive(ch) }
+        let result = await_timeout(h, 10)
+        close(ch)
+        result
+    "#,
+    );
+    assert_eq!(out, "null");
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -2986,9 +2986,158 @@ impl VM {
                 }
             }
 
+            "await_all" => {
+                if args.is_empty() {
+                    return Err(VMError::new(
+                        "await_all() requires an array of task handles",
+                    ));
+                }
+                // Extract array items, releasing the GC borrow
+                let items: Vec<Value> = match &args[0] {
+                    Value::Obj(r) => match self.gc.get(*r) {
+                        Some(obj) => match &obj.kind {
+                            ObjKind::Array(arr) => arr.clone(),
+                            _ => {
+                                return Err(VMError::new(
+                                    "await_all() requires an array of task handles",
+                                ))
+                            }
+                        },
+                        None => {
+                            return Err(VMError::new(
+                                "await_all() requires an array of task handles",
+                            ))
+                        }
+                    },
+                    _ => {
+                        return Err(VMError::new(
+                            "await_all() requires an array of task handles",
+                        ))
+                    }
+                };
+                let mut results = Vec::with_capacity(items.len());
+                for item in &items {
+                    let maybe_slot = self.extract_task_handle(item);
+                    if let Some(slot) = maybe_slot {
+                        let (lock, cvar) = &*slot;
+                        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                        while guard.is_none() {
+                            guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
+                        }
+                        let shared = guard.as_ref().cloned().unwrap_or(SharedValue::Null);
+                        let val = shared_to_value(&mut self.gc, &shared);
+                        // Fail-fast: propagate ResultErr immediately
+                        match &val {
+                            Value::Obj(r) => {
+                                if let Some(obj) = self.gc.get(*r) {
+                                    if let ObjKind::ResultErr(e) = &obj.kind {
+                                        let msg = e.display(&self.gc);
+                                        return Err(VMError::new(&format!("task error: {}", msg)));
+                                    }
+                                    if let ObjKind::ResultOk(v) = &obj.kind {
+                                        let unwrapped = *v;
+                                        results.push(unwrapped);
+                                        continue;
+                                    }
+                                }
+                                results.push(val);
+                            }
+                            _ => results.push(val),
+                        }
+                    } else {
+                        // Non-task-handle values pass through
+                        results.push(*item);
+                    }
+                }
+                let r = self.gc.alloc(ObjKind::Array(results));
+                Ok(Value::Obj(r))
+            }
+            "await_timeout" => {
+                if args.len() < 2 {
+                    return Err(VMError::new(
+                        "await_timeout() requires (handle, timeout_ms)",
+                    ));
+                }
+                let timeout_ms = match &args[1] {
+                    Value::Int(ms) => (*ms).max(0) as u64,
+                    Value::Float(ms) => ms.max(0.0) as u64,
+                    _ => {
+                        return Err(VMError::new(
+                            "await_timeout() second argument must be a number (ms)",
+                        ))
+                    }
+                };
+                let maybe_slot = self.extract_task_handle(&args[0]);
+                match maybe_slot {
+                    Some(slot) => {
+                        let (lock, cvar) = &*slot;
+                        let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                        if guard.is_none() {
+                            let deadline = std::time::Duration::from_millis(timeout_ms);
+                            let start = std::time::Instant::now();
+                            loop {
+                                let remaining = deadline.saturating_sub(start.elapsed());
+                                if remaining.is_zero() {
+                                    return Ok(Value::Null);
+                                }
+                                let (g, timeout_result) = cvar
+                                    .wait_timeout(guard, remaining)
+                                    .unwrap_or_else(|e| e.into_inner());
+                                guard = g;
+                                if guard.is_some() {
+                                    break;
+                                }
+                                if timeout_result.timed_out() {
+                                    return Ok(Value::Null);
+                                }
+                            }
+                        }
+                        let shared = guard.as_ref().cloned().unwrap_or(SharedValue::Null);
+                        let val = shared_to_value(&mut self.gc, &shared);
+                        // Unwrap ResultOk, propagate ResultErr
+                        match &val {
+                            Value::Obj(r) => {
+                                if let Some(obj) = self.gc.get(*r) {
+                                    if let ObjKind::ResultOk(v) = &obj.kind {
+                                        return Ok(*v);
+                                    }
+                                    if let ObjKind::ResultErr(e) = &obj.kind {
+                                        let msg = e.display(&self.gc);
+                                        return Err(VMError::new(&format!("task error: {}", msg)));
+                                    }
+                                }
+                                Ok(val)
+                            }
+                            _ => Ok(val),
+                        }
+                    }
+                    None => {
+                        return Err(VMError::new(
+                            "await_timeout() first argument must be a task handle",
+                        ))
+                    }
+                }
+            }
+
             // Note: lowercase ok/err aliases are handled ABOVE (before "Ok"/"Err") to avoid
             // unreachable pattern warnings. The dead duplicates below have been removed.
             _ => Err(VMError::new(&format!("unknown builtin: {}", name))),
+        }
+    }
+
+    fn extract_task_handle(
+        &self,
+        val: &Value,
+    ) -> Option<Arc<(std::sync::Mutex<Option<SharedValue>>, std::sync::Condvar)>> {
+        match val {
+            Value::Obj(r) => self.gc.get(*r).and_then(|obj| {
+                if let ObjKind::TaskHandle(slot) = &obj.kind {
+                    Some(slot.clone())
+                } else {
+                    None
+                }
+            }),
+            _ => None,
         }
     }
 

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -503,6 +503,8 @@ impl VM {
             "try_send",
             "try_receive",
             "select",
+            "await_all",
+            "await_timeout",
         ];
         for name in &builtins {
             let name_ref = self.gc.alloc(ObjKind::NativeFunction(NativeFn {


### PR DESCRIPTION
## Summary

- `await_all(handles)` — wait on array of task handles, collect results. Fail-fast on ResultErr. Non-task values pass through.
- `await_timeout(handle, ms)` — wait with deadline, returns null on timeout. Handles spurious wakeups via remaining-duration loop.
- `extract_task_handle()` helper for Arc extraction from ObjKind::TaskHandle

Roadmap item: `VM async coordination: await_all(), await_timeout()`

## Test plan

- [x] `vm_await_all_basic` — 3 spawns, collect results
- [x] `vm_await_all_empty` — empty array returns `[]`
- [x] `vm_await_all_mixed` — task handles + plain values
- [x] `vm_await_timeout_completes` — task finishes within deadline
- [x] `vm_await_timeout_expires` — task blocked, returns null after 10ms
- [x] 1142 total tests pass