### PR TITLE
feat: VM time() builtin with __call__ dispatch

### DIFF
--- a/.planning/vm-time-builtin.plan.md
+++ b/.planning/vm-time-builtin.plan.md
@@ -1,0 +1,27 @@
+# Plan: VM time() builtin
+
+## Goal
+
+Port `time()` builtin from interpreter to VM. Returns a datetime object with iso, unix, year, month, day, hour, minute, second, weekday, timezone fields.
+
+## Design
+
+- Call `chrono::Utc::now()` directly in builtins.rs
+- Build `ObjKind::Object(IndexMap)` with same fields as interpreter's `datetime_to_value()`
+- String fields allocated via `gc.alloc(ObjKind::String(...))`
+- Int fields stored as `Value::Int`
+
+## Files
+
+1. `src/vm/builtins.rs` — add "time" handler
+2. `src/vm/machine.rs` — register "time" builtin
+3. `src/vm/async_tests.rs` — test (or new test file section)
+
+## Tests
+
+1. `vm_time_returns_object` — time() returns object with expected keys
+2. `vm_time_unix_positive` — unix field > 1_700_000_000
+
+## Rollback
+
+Revert builtins.rs, machine.rs, test file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **VM channel builtins** — `channel()`, `send()`, `receive()`, `close()` now work in `--vm` mode. Supports bounded and unbounded channels with cross-spawn communication. ([#87](https://github.com/humancto/forge-lang/pull/87))
 - **VM channel extras** — `try_send()`, `try_receive()`, `select()` now work in `--vm` mode. Non-blocking channel operations and multi-channel select with optional timeout. ([#88](https://github.com/humancto/forge-lang/pull/88))
 - **VM async coordination** — `await_all()` and `await_timeout()` now work in `--vm` mode. Await multiple task handles or a single handle with a deadline. ([#89](https://github.com/humancto/forge-lang/pull/89))
+- **VM `time()` builtin** — `time()` now works in `--vm` mode, returning a datetime object with iso, unix, year, month, day, hour, minute, second, weekday, and timezone fields. Module-as-function via `__call__` dispatch. ([#90](https://github.com/humancto/forge-lang/pull/90))
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/vm/async_tests.rs
+++ b/src/vm/async_tests.rs
@@ -486,3 +486,42 @@ fn vm_await_timeout_expires() {
     );
     assert_eq!(out, "null");
 }
+
+// ----- time() builtin -----
+
+#[test]
+fn vm_time_returns_object() {
+    let out = run_on_vm(
+        r#"
+        let t = time()
+        println(type(t))
+        println(has_key(t, "unix"))
+        println(has_key(t, "year"))
+        println(has_key(t, "iso"))
+        println(has_key(t, "timezone"))
+    "#,
+    );
+    assert_eq!(out, vec!["Object", "true", "true", "true", "true"]);
+}
+
+#[test]
+fn vm_time_unix_positive() {
+    let out = run_on_vm(
+        r#"
+        let t = time()
+        println(t.unix > 1700000000)
+    "#,
+    );
+    assert_eq!(out, vec!["true"]);
+}
+
+#[test]
+fn vm_time_year_reasonable() {
+    let out = run_on_vm(
+        r#"
+        let t = time()
+        println(t.year >= 2026)
+    "#,
+    );
+    assert_eq!(out, vec!["true"]);
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -2,6 +2,7 @@
 /// Extracted from machine.rs to keep that file navigable.
 /// This is a continuation of `impl VM` — same struct, separate file.
 /// Do NOT change logic here; this is a pure structural extraction.
+use chrono::{Datelike, Timelike, Utc};
 use indexmap::IndexMap;
 use std::sync::Arc;
 
@@ -2986,6 +2987,31 @@ impl VM {
                 }
             }
 
+            "time" => {
+                let now = Utc::now();
+                let mut m = IndexMap::new();
+                m.insert("iso".to_string(), self.alloc_string(&now.to_rfc3339()));
+                m.insert("unix".to_string(), Value::Int(now.timestamp()));
+                m.insert("unix_ms".to_string(), Value::Int(now.timestamp_millis()));
+                m.insert("year".to_string(), Value::Int(now.year() as i64));
+                m.insert("month".to_string(), Value::Int(now.month() as i64));
+                m.insert("day".to_string(), Value::Int(now.day() as i64));
+                m.insert("hour".to_string(), Value::Int(now.hour() as i64));
+                m.insert("minute".to_string(), Value::Int(now.minute() as i64));
+                m.insert("second".to_string(), Value::Int(now.second() as i64));
+                m.insert(
+                    "weekday".to_string(),
+                    self.alloc_string(&now.format("%A").to_string()),
+                );
+                m.insert(
+                    "weekday_short".to_string(),
+                    self.alloc_string(&now.format("%a").to_string()),
+                );
+                m.insert("day_of_year".to_string(), Value::Int(now.ordinal() as i64));
+                m.insert("timezone".to_string(), self.alloc_string("UTC"));
+                let r = self.gc.alloc(ObjKind::Object(m));
+                Ok(Value::Obj(r))
+            }
             "await_all" => {
                 if args.is_empty() {
                     return Err(VMError::new(

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -724,6 +724,11 @@ impl VM {
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
             time_map.insert(name.to_string(), Value::Obj(nr));
         }
+        // time() as a function calls the "time" builtin (returns datetime object)
+        let time_call = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
+            name: "time".to_string(),
+        }));
+        time_map.insert("__call__".to_string(), Value::Obj(time_call));
         let time_ref = self.gc.alloc(ObjKind::Object(time_map));
         self.globals
             .insert("time".to_string(), Value::Obj(time_ref));
@@ -2219,6 +2224,14 @@ impl VM {
                     ObjKind::NativeFunction(nf) => {
                         let name = nf.name.clone();
                         self.call_native(&name, args)
+                    }
+                    ObjKind::Object(map) => {
+                        // Module-as-function: if the object has a __call__ field, call it
+                        if let Some(call_fn) = map.get("__call__").copied() {
+                            self.call_value(call_fn, args)
+                        } else {
+                            Err(VMError::new("cannot call non-function"))
+                        }
                     }
                     _ => Err(VMError::new("cannot call non-function")),
                 }


### PR DESCRIPTION
## Summary

- time() now works in --vm mode, returning a datetime object matching the interpreter format
- Introduces __call__ convention: when an Object is called as a function, the VM checks for a __call__ field containing a NativeFunction
- Uses chrono::Utc::now() directly in VM builtins

Roadmap item: VM time() builtin

## Test plan

- [x] vm_time_returns_object - returns Object with expected keys
- [x] vm_time_unix_positive - unix timestamp > 1,700,000,000
- [x] vm_time_year_reasonable - year >= 2026
- [x] 1145 total tests pass