### PR TITLE
refactor: migrate VM Value to 8-byte NaN-boxed newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **VM async coordination** — `await_all()` and `await_timeout()` now work in `--vm` mode. Await multiple task handles or a single handle with a deadline. ([#89](https://github.com/humancto/forge-lang/pull/89))
 - **VM `time()` builtin** — `time()` now works in `--vm` mode, returning a datetime object with iso, unix, year, month, day, hour, minute, second, weekday, and timezone fields. Module-as-function via `__call__` dispatch. ([#90](https://github.com/humancto/forge-lang/pull/90))
 - **NaN-boxed value encoding** — New `nanbox` module implements 8-byte NaN-boxed value representation (vs current 16-byte enum). Encodes Int/Float/Bool/Null/Obj in a single u64 using IEEE 754 quiet NaN payload bits. 40 unit tests. ([#91](https://github.com/humancto/forge-lang/pull/91))
+- **NaN-boxed VM migration** — VM `Value` type migrated from 16-byte enum to 8-byte NaN-boxed newtype, halving memory for all registers, arrays, and objects. Integers >48 bits transparently heap-allocate via `BoxedInt`. Three-tier arithmetic overflow: inline → BoxedInt → float.
 
 ## [0.8.0] - 2026-04-12
 

--- a/src/stdlib/fs.rs
+++ b/src/stdlib/fs.rs
@@ -351,8 +351,8 @@ pub fn call_vm(
     gc: &crate::vm::gc::Gc,
 ) -> Result<FsResult, String> {
     let get_str = |v: &crate::vm::value::Value| -> Option<String> {
-        if let crate::vm::value::Value::Obj(r) = v {
-            if let Some(obj) = gc.get(*r) {
+        if let Some(r) = v.as_obj() {
+            if let Some(obj) = gc.get(r) {
                 if let crate::vm::value::ObjKind::String(s) = &obj.kind {
                     return Some(s.clone());
                 }

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -112,15 +112,15 @@ pub fn call_vm(
             std::io::stdin()
                 .read_line(&mut input)
                 .map_err(|e| format!("{}", e))?;
-            Ok(V::Null) // VM needs GC to alloc string; caller handles
+            Ok(V::null()) // VM needs GC to alloc string; caller handles
         }
         "io.print" => {
             let text: Vec<String> = args.iter().map(|v| v.display(gc)).collect();
             print!("{}", text.join(" "));
-            Ok(V::Null)
+            Ok(V::null())
         }
         "io.args" => {
-            Ok(V::Null) // Would need GC to alloc array
+            Ok(V::null()) // Would need GC to alloc array
         }
         _ => Err(format!("unknown io function: {}", name)),
     }

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -171,122 +171,183 @@ pub fn call(name: &str, args: Vec<Value>) -> Result<Value, String> {
 pub fn call_vm(
     name: &str,
     args: &[crate::vm::value::Value],
-    _gc: &crate::vm::gc::Gc,
+    gc: &crate::vm::gc::Gc,
 ) -> Result<crate::vm::value::Value, String> {
-    use crate::vm::value::Value as V;
+    use crate::vm::value::{Value as V, ValueKind as VK};
+
+    // Helper to extract a number from a VM value
+    let as_num = |v: &V| -> Option<(Option<i64>, Option<f64>)> {
+        match v.classify(gc) {
+            VK::Int(n) => Some((Some(n), None)),
+            VK::Float(f) => Some((None, Some(f))),
+            _ => None,
+        }
+    };
+
+    let as_f64 = |v: &V| -> Option<f64> {
+        match v.classify(gc) {
+            VK::Int(n) => Some(n as f64),
+            VK::Float(f) => Some(f),
+            _ => None,
+        }
+    };
+
     match name {
-        "math.sqrt" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Float(n.sqrt())),
-            Some(V::Int(n)) => Ok(V::Float((*n as f64).sqrt())),
-            _ => Err("math.sqrt() requires a number".to_string()),
-        },
-        "math.pow" => match (args.first(), args.get(1)) {
-            (Some(V::Int(b)), Some(V::Int(e))) => {
-                if *e < 0 {
-                    Ok(V::Float((*b as f64).powf(*e as f64)))
-                } else {
-                    match (*e).try_into() {
-                        Ok(exp) => Ok(V::Int(b.pow(exp))),
-                        Err(_) => Ok(V::Float((*b as f64).powf(*e as f64))),
+        "math.sqrt" => {
+            let f = as_f64(args.first().ok_or("math.sqrt() requires a number")?)
+                .ok_or("math.sqrt() requires a number".to_string())?;
+            Ok(V::float(f.sqrt()))
+        }
+        "math.pow" => {
+            let (b, e) = (args.first(), args.get(1));
+            let (Some(b), Some(e)) = (b, e) else {
+                return Err("math.pow() requires two numbers".to_string());
+            };
+            let (bn, en) = (as_num(b), as_num(e));
+            match (bn, en) {
+                (Some((Some(bi), _)), Some((Some(ei), _))) => {
+                    if ei < 0 {
+                        Ok(V::float((bi as f64).powf(ei as f64)))
+                    } else {
+                        match ei.try_into() {
+                            Ok(exp) => Ok(V::small_int(bi.pow(exp))),
+                            Err(_) => Ok(V::float((bi as f64).powf(ei as f64))),
+                        }
                     }
                 }
+                _ => {
+                    let bf = as_f64(b).ok_or("math.pow() requires two numbers".to_string())?;
+                    let ef = as_f64(e).ok_or("math.pow() requires two numbers".to_string())?;
+                    Ok(V::float(bf.powf(ef)))
+                }
             }
-            (Some(V::Float(b)), Some(V::Float(e))) => Ok(V::Float(b.powf(*e))),
-            (Some(V::Int(b)), Some(V::Float(e))) => Ok(V::Float((*b as f64).powf(*e))),
-            (Some(V::Float(b)), Some(V::Int(e))) => Ok(V::Float(b.powf(*e as f64))),
-            _ => Err("math.pow() requires two numbers".to_string()),
-        },
-        "math.abs" => match args.first() {
-            Some(V::Int(n)) => Ok(V::Int(n.abs())),
-            Some(V::Float(n)) => Ok(V::Float(n.abs())),
-            _ => Err("math.abs() requires a number".to_string()),
-        },
-        "math.max" => match (args.first(), args.get(1)) {
-            (Some(V::Int(a)), Some(V::Int(b))) => Ok(V::Int(*a.max(b))),
-            (Some(V::Float(a)), Some(V::Float(b))) => Ok(V::Float(a.max(*b))),
-            _ => Err("math.max() requires two numbers".to_string()),
-        },
-        "math.min" => match (args.first(), args.get(1)) {
-            (Some(V::Int(a)), Some(V::Int(b))) => Ok(V::Int(*a.min(b))),
-            (Some(V::Float(a)), Some(V::Float(b))) => Ok(V::Float(a.min(*b))),
-            _ => Err("math.min() requires two numbers".to_string()),
-        },
-        "math.floor" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Int(n.floor() as i64)),
-            Some(V::Int(n)) => Ok(V::Int(*n)),
-            _ => Err("math.floor() requires a number".to_string()),
-        },
-        "math.ceil" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Int(n.ceil() as i64)),
-            Some(V::Int(n)) => Ok(V::Int(*n)),
-            _ => Err("math.ceil() requires a number".to_string()),
-        },
-        "math.round" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Int(n.round() as i64)),
-            Some(V::Int(n)) => Ok(V::Int(*n)),
-            _ => Err("math.round() requires a number".to_string()),
-        },
+        }
+        "math.abs" => {
+            let v = args.first().ok_or("math.abs() requires a number")?;
+            match v.classify(gc) {
+                VK::Int(n) => Ok(V::small_int(n.abs())),
+                VK::Float(f) => Ok(V::float(f.abs())),
+                _ => Err("math.abs() requires a number".to_string()),
+            }
+        }
+        "math.max" => {
+            let (Some(a), Some(b)) = (args.first(), args.get(1)) else {
+                return Err("math.max() requires two numbers".to_string());
+            };
+            match (a.classify(gc), b.classify(gc)) {
+                (VK::Int(a), VK::Int(b)) => Ok(V::small_int(a.max(b))),
+                _ => {
+                    let af = as_f64(a).ok_or("math.max() requires two numbers".to_string())?;
+                    let bf = as_f64(b).ok_or("math.max() requires two numbers".to_string())?;
+                    Ok(V::float(af.max(bf)))
+                }
+            }
+        }
+        "math.min" => {
+            let (Some(a), Some(b)) = (args.first(), args.get(1)) else {
+                return Err("math.min() requires two numbers".to_string());
+            };
+            match (a.classify(gc), b.classify(gc)) {
+                (VK::Int(a), VK::Int(b)) => Ok(V::small_int(a.min(b))),
+                _ => {
+                    let af = as_f64(a).ok_or("math.min() requires two numbers".to_string())?;
+                    let bf = as_f64(b).ok_or("math.min() requires two numbers".to_string())?;
+                    Ok(V::float(af.min(bf)))
+                }
+            }
+        }
+        "math.floor" => {
+            let v = args.first().ok_or("math.floor() requires a number")?;
+            match v.classify(gc) {
+                VK::Float(n) => Ok(V::small_int(n.floor() as i64)),
+                VK::Int(n) => Ok(V::small_int(n)),
+                _ => Err("math.floor() requires a number".to_string()),
+            }
+        }
+        "math.ceil" => {
+            let v = args.first().ok_or("math.ceil() requires a number")?;
+            match v.classify(gc) {
+                VK::Float(n) => Ok(V::small_int(n.ceil() as i64)),
+                VK::Int(n) => Ok(V::small_int(n)),
+                _ => Err("math.ceil() requires a number".to_string()),
+            }
+        }
+        "math.round" => {
+            let v = args.first().ok_or("math.round() requires a number")?;
+            match v.classify(gc) {
+                VK::Float(n) => Ok(V::small_int(n.round() as i64)),
+                VK::Int(n) => Ok(V::small_int(n)),
+                _ => Err("math.round() requires a number".to_string()),
+            }
+        }
         "math.random" => {
             let r = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .subsec_nanos() as f64
                 / 1_000_000_000.0;
-            Ok(V::Float(r))
+            Ok(V::float(r))
         }
-        "math.sin" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Float(n.sin())),
-            Some(V::Int(n)) => Ok(V::Float((*n as f64).sin())),
-            _ => Err("math.sin() requires a number".to_string()),
-        },
-        "math.cos" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Float(n.cos())),
-            Some(V::Int(n)) => Ok(V::Float((*n as f64).cos())),
-            _ => Err("math.cos() requires a number".to_string()),
-        },
-        "math.tan" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Float(n.tan())),
-            Some(V::Int(n)) => Ok(V::Float((*n as f64).tan())),
-            _ => Err("math.tan() requires a number".to_string()),
-        },
-        "math.log" => match args.first() {
-            Some(V::Float(n)) => Ok(V::Float(n.ln())),
-            Some(V::Int(n)) => Ok(V::Float((*n as f64).ln())),
-            _ => Err("math.log() requires a number".to_string()),
-        },
-        "math.random_int" => match (args.first(), args.get(1)) {
-            (Some(V::Int(min)), Some(V::Int(max))) => {
-                if min > max {
-                    return Err(format!(
-                        "math.random_int() requires min <= max, got {} > {}",
-                        min, max
-                    ));
+        "math.sin" => {
+            let f = as_f64(args.first().ok_or("math.sin() requires a number")?)
+                .ok_or("math.sin() requires a number".to_string())?;
+            Ok(V::float(f.sin()))
+        }
+        "math.cos" => {
+            let f = as_f64(args.first().ok_or("math.cos() requires a number")?)
+                .ok_or("math.cos() requires a number".to_string())?;
+            Ok(V::float(f.cos()))
+        }
+        "math.tan" => {
+            let f = as_f64(args.first().ok_or("math.tan() requires a number")?)
+                .ok_or("math.tan() requires a number".to_string())?;
+            Ok(V::float(f.tan()))
+        }
+        "math.log" => {
+            let f = as_f64(args.first().ok_or("math.log() requires a number")?)
+                .ok_or("math.log() requires a number".to_string())?;
+            Ok(V::float(f.ln()))
+        }
+        "math.random_int" => {
+            let (Some(a), Some(b)) = (args.first(), args.get(1)) else {
+                return Err("math.random_int() requires two integers (min, max)".to_string());
+            };
+            let (Some(min), Some(max)) = (a.as_int(gc), b.as_int(gc)) else {
+                return Err("math.random_int() requires two integers (min, max)".to_string());
+            };
+            if min > max {
+                return Err(format!(
+                    "math.random_int() requires min <= max, got {} > {}",
+                    min, max
+                ));
+            }
+            use std::time::SystemTime;
+            let nanos = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos() as i64;
+            let range = max - min + 1;
+            Ok(V::small_int(min + (nanos.abs() % range)))
+        }
+        "math.clamp" => {
+            let (Some(v), Some(lo), Some(hi)) = (args.first(), args.get(1), args.get(2)) else {
+                return Err("math.clamp() requires (value, min, max) numbers".to_string());
+            };
+            match (v.classify(gc), lo.classify(gc), hi.classify(gc)) {
+                (VK::Int(val), VK::Int(min), VK::Int(max)) => {
+                    Ok(V::small_int(val.max(min).min(max)))
                 }
-                use std::time::SystemTime;
-                let nanos = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .subsec_nanos() as i64;
-                let range = max - min + 1;
-                Ok(V::Int(min + (nanos.abs() % range)))
+                _ => {
+                    let vf = as_f64(v)
+                        .ok_or("math.clamp() requires (value, min, max) numbers".to_string())?;
+                    let lf = as_f64(lo)
+                        .ok_or("math.clamp() requires (value, min, max) numbers".to_string())?;
+                    let hf = as_f64(hi)
+                        .ok_or("math.clamp() requires (value, min, max) numbers".to_string())?;
+                    Ok(V::float(vf.max(lf).min(hf)))
+                }
             }
-            _ => Err("math.random_int() requires two integers (min, max)".to_string()),
-        },
-        "math.clamp" => match (args.first(), args.get(1), args.get(2)) {
-            (Some(V::Int(val)), Some(V::Int(min)), Some(V::Int(max))) => {
-                Ok(V::Int((*val).max(*min).min(*max)))
-            }
-            (Some(V::Float(val)), Some(V::Float(min)), Some(V::Float(max))) => {
-                Ok(V::Float(val.max(*min).min(*max)))
-            }
-            (Some(V::Int(val)), Some(V::Float(min)), Some(V::Float(max))) => {
-                Ok(V::Float((*val as f64).max(*min).min(*max)))
-            }
-            (Some(V::Float(val)), Some(V::Int(min)), Some(V::Int(max))) => {
-                Ok(V::Float(val.max(*min as f64).min(*max as f64)))
-            }
-            _ => Err("math.clamp() requires (value, min, max) numbers".to_string()),
-        },
+        }
         _ => Err(format!("unknown math function: {}", name)),
     }
 }

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -55,7 +55,7 @@ impl VM {
                 }
                 fields.insert("__type__".to_string(), self.alloc_string(&type_name));
                 let r = self.gc.alloc(ObjKind::Object(fields));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "__forge_register_interface" => {
                 if args.len() != 2 {
@@ -118,7 +118,7 @@ impl VM {
                         .insert(method_name, func);
                 }
 
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "__forge_validate_impl" => {
                 if args.len() != 2 {
@@ -144,7 +144,7 @@ impl VM {
                         )));
                     }
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "__forge_call_method" => {
                 if args.len() < 2 {
@@ -166,25 +166,25 @@ impl VM {
                 let value = args[1].clone();
 
                 let Some(bound_value) = self.globals.get(&binding_name).cloned() else {
-                    return Ok(Value::Bool(true));
+                    return Ok(Value::bool_val(true));
                 };
 
                 if let (Some(bound_variant), Some(value_variant)) = (
                     self.value_variant_name(&bound_value),
                     self.value_variant_name(&value),
                 ) {
-                    return Ok(Value::Bool(bound_variant == value_variant));
+                    return Ok(Value::bool_val(bound_variant == value_variant));
                 }
 
-                Ok(Value::Bool(true))
+                Ok(Value::bool_val(true))
             }
             "__forge_retry_count" => {
                 if args.len() != 1 {
                     return Err(VMError::new("__forge_retry_count() requires (count)"));
                 }
                 match args[0] {
-                    Value::Int(n) => Ok(Value::Int(n.max(0))),
-                    _ => Ok(Value::Int(3)),
+                    Value::Int(n) => Ok(Value::small_int(n.max(0))),
+                    _ => Ok(Value::small_int(3)),
                 }
             }
             "__forge_retry_wait" => {
@@ -198,7 +198,7 @@ impl VM {
                 if attempt > 0 {
                     std::thread::sleep(std::time::Duration::from_millis(100 * attempt));
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "__forge_retry_failed" => {
                 if args.len() != 2 {
@@ -249,7 +249,7 @@ impl VM {
                     })
                     .collect::<Vec<_>>();
                 let r = self.gc.alloc(ObjKind::Array(filtered));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "__forge_pipe_sort" => {
                 if args.len() != 2 {
@@ -262,15 +262,15 @@ impl VM {
                     let left = self
                         .get_object_fields(a)
                         .and_then(|fields| fields.get(&field).cloned())
-                        .unwrap_or(Value::Null);
+                        .unwrap_or(Value::null());
                     let right = self
                         .get_object_fields(b)
                         .and_then(|fields| fields.get(&field).cloned())
-                        .unwrap_or(Value::Null);
+                        .unwrap_or(Value::null());
                     self.query_value_cmp(&left, &right)
                 });
                 let r = self.gc.alloc(ObjKind::Array(items));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "__forge_pipe_take" => {
                 if args.len() != 2 {
@@ -286,7 +286,7 @@ impl VM {
                 let r = self
                     .gc
                     .alloc(ObjKind::Array(items.into_iter().take(count).collect()));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "__forge_raise_error" => {
                 if args.len() != 1 {
@@ -382,33 +382,33 @@ impl VM {
                     exports.insert(name, value);
                 }
                 let exports_ref = self.gc.alloc(ObjKind::Object(exports));
-                Ok(Value::Obj(exports_ref))
+                Ok(Value::obj(exports_ref))
             }
             "println" | "say" => {
                 let text: Vec<String> = args.iter().map(|v| v.display(&self.gc)).collect();
                 let output = text.join(" ");
                 println!("{}", output);
                 self.output.push(output);
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "print" => {
                 let text: Vec<String> = args.iter().map(|v| v.display(&self.gc)).collect();
                 print!("{}", text.join(" "));
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "yell" => {
                 let text: Vec<String> = args.iter().map(|v| v.display(&self.gc)).collect();
                 let output = text.join(" ").to_uppercase();
                 println!("{}", output);
                 self.output.push(output);
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "whisper" => {
                 let text: Vec<String> = args.iter().map(|v| v.display(&self.gc)).collect();
                 let output = text.join(" ").to_lowercase();
                 println!("{}", output);
                 self.output.push(output);
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "len" => match args.first() {
                 Some(v) => {
@@ -421,7 +421,7 @@ impl VM {
                         }),
                         _ => 0,
                     };
-                    Ok(Value::Int(len))
+                    Ok(Value::small_int(len))
                 }
                 None => Err(VMError::new("len() requires an argument")),
             },
@@ -440,30 +440,33 @@ impl VM {
                 Ok(self.alloc_string(&s))
             }
             "int" => match args.first() {
-                Some(Value::Int(n)) => Ok(Value::Int(*n)),
-                Some(Value::Float(n)) => Ok(Value::Int(*n as i64)),
+                Some(Value::Int(n)) => Ok(Value::int(*n, &mut self.gc)),
+                Some(Value::Float(n)) => Ok(Value::int(*n as i64, &mut self.gc)),
                 // Parity with interpreter: bool → 0/1
-                Some(Value::Bool(b)) => Ok(Value::Int(if *b { 1 } else { 0 })),
+                Some(Value::Bool(b)) => Ok(Value::small_int(if *b { 1 } else { 0 })),
                 Some(Value::Obj(r)) => {
-                    if let Some(obj) = self.gc.get(*r) {
-                        if let ObjKind::String(s) = &obj.kind {
-                            return s.parse::<i64>().map(Value::Int).map_err(|_| {
-                                VMError::new(&format!("cannot convert '{}' to Int", s))
-                            });
-                        }
+                    let s_owned = self.gc.get(*r).and_then(|obj| match &obj.kind {
+                        ObjKind::String(s) => Some(s.clone()),
+                        _ => None,
+                    });
+                    if let Some(s) = s_owned {
+                        return s
+                            .parse::<i64>()
+                            .map(|n| Value::int(n, &mut self.gc))
+                            .map_err(|_| VMError::new(&format!("cannot convert '{}' to Int", s)));
                     }
                     Err(VMError::new("int() requires number, bool, or string"))
                 }
                 _ => Err(VMError::new("int() requires number, bool, or string")),
             },
             "float" => match args.first() {
-                Some(Value::Int(n)) => Ok(Value::Float(*n as f64)),
-                Some(Value::Float(n)) => Ok(Value::Float(*n)),
+                Some(Value::Int(n)) => Ok(Value::float(*n as f64)),
+                Some(Value::Float(n)) => Ok(Value::float(*n)),
                 // Parity with interpreter: parse string to float
                 Some(Value::Obj(r)) => {
                     if let Some(obj) = self.gc.get(*r) {
                         if let ObjKind::String(s) = &obj.kind {
-                            return s.parse::<f64>().map(Value::Float).map_err(|_| {
+                            return s.parse::<f64>().map(Value::float).map_err(|_| {
                                 VMError::new(&format!("cannot convert '{}' to Float", s))
                             });
                         }
@@ -476,12 +479,12 @@ impl VM {
                 (Some(Value::Int(start)), Some(Value::Int(end))) => {
                     let items: Vec<Value> = (*start..*end).map(Value::Int).collect();
                     let r = self.gc.alloc(ObjKind::Array(items));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 }
                 (Some(Value::Int(end_val)), None) => {
                     let items: Vec<Value> = (0..*end_val).map(Value::Int).collect();
                     let r = self.gc.alloc(ObjKind::Array(items));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 }
                 _ => Err(VMError::new("range() requires integer arguments")),
             },
@@ -495,7 +498,7 @@ impl VM {
                             let mut new_items = items.clone();
                             new_items.push(args[1].clone());
                             let nr = self.gc.alloc(ObjKind::Array(new_items));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                     }
                 }
@@ -508,7 +511,7 @@ impl VM {
                             let mut new_items = items.clone();
                             new_items.pop();
                             let nr = self.gc.alloc(ObjKind::Array(new_items));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                     }
                 }
@@ -517,9 +520,9 @@ impl VM {
             // Lowercase aliases must come BEFORE the capitalized forms
             // so the match arms are not shadowed ("Ok" would match before "ok" | "Ok")
             "ok" => {
-                let val = args.first().cloned().unwrap_or(Value::Null);
+                let val = args.first().cloned().unwrap_or(Value::null());
                 let r = self.gc.alloc(ObjKind::ResultOk(val));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "err" => {
                 let val = args
@@ -527,20 +530,20 @@ impl VM {
                     .cloned()
                     .unwrap_or_else(|| self.alloc_string("error"));
                 let r = self.gc.alloc(ObjKind::ResultErr(val));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "Ok" | "Some" => {
-                let val = args.first().cloned().unwrap_or(Value::Null);
+                let val = args.first().cloned().unwrap_or(Value::null());
                 if name == "Some" {
                     let mut obj = IndexMap::new();
                     obj.insert("__type__".to_string(), self.alloc_string("Option"));
                     obj.insert("__variant__".to_string(), self.alloc_string("Some"));
                     obj.insert("_0".to_string(), val);
                     let r = self.gc.alloc(ObjKind::Object(obj));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 } else {
                     let r = self.gc.alloc(ObjKind::ResultOk(val));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 }
             }
             "Err" => {
@@ -549,23 +552,23 @@ impl VM {
                     .cloned()
                     .unwrap_or_else(|| self.alloc_string("error"));
                 let r = self.gc.alloc(ObjKind::ResultErr(val));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "is_ok" => {
                 if let Some(Value::Obj(r)) = args.first() {
                     if let Some(obj) = self.gc.get(*r) {
-                        return Ok(Value::Bool(matches!(obj.kind, ObjKind::ResultOk(_))));
+                        return Ok(Value::bool_val(matches!(obj.kind, ObjKind::ResultOk(_))));
                     }
                 }
-                Ok(Value::Bool(false))
+                Ok(Value::bool_val(false))
             }
             "is_err" => {
                 if let Some(Value::Obj(r)) = args.first() {
                     if let Some(obj) = self.gc.get(*r) {
-                        return Ok(Value::Bool(matches!(obj.kind, ObjKind::ResultErr(_))));
+                        return Ok(Value::bool_val(matches!(obj.kind, ObjKind::ResultErr(_))));
                     }
                 }
-                Ok(Value::Bool(false))
+                Ok(Value::bool_val(false))
             }
             "unwrap" => {
                 if let Some(Value::Obj(r)) = args.first() {
@@ -600,7 +603,7 @@ impl VM {
                 Ok(args[1].clone())
             }
             "assert" => {
-                let cond = args.first().cloned().unwrap_or(Value::Bool(false));
+                let cond = args.first().cloned().unwrap_or(Value::bool_val(false));
                 if !cond.is_truthy(&self.gc) {
                     let msg = args
                         .get(1)
@@ -608,7 +611,7 @@ impl VM {
                         .unwrap_or_else(|| "assertion failed".to_string());
                     return Err(VMError::new(&format!("assertion failed: {}", msg)));
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "assert_eq" => {
                 if args.len() < 2 {
@@ -622,7 +625,7 @@ impl VM {
                         right, left
                     )));
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "assert_ne" => {
                 if args.len() < 2 {
@@ -635,7 +638,7 @@ impl VM {
                         left
                     )));
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "any" => {
                 if args.len() < 2 {
@@ -660,10 +663,10 @@ impl VM {
                         .call_value(func.clone(), vec![item])?
                         .is_truthy(&self.gc)
                     {
-                        return Ok(Value::Bool(true));
+                        return Ok(Value::bool_val(true));
                     }
                 }
-                Ok(Value::Bool(false))
+                Ok(Value::bool_val(false))
             }
             "all" => {
                 if args.len() < 2 {
@@ -688,10 +691,10 @@ impl VM {
                         .call_value(func.clone(), vec![item])?
                         .is_truthy(&self.gc)
                     {
-                        return Ok(Value::Bool(false));
+                        return Ok(Value::bool_val(false));
                     }
                 }
-                Ok(Value::Bool(true))
+                Ok(Value::bool_val(true))
             }
             "unique" => {
                 if let Some(Value::Obj(r)) = args.first() {
@@ -714,7 +717,7 @@ impl VM {
                         }
                     }
                     let r = self.gc.alloc(ObjKind::Array(out));
-                    return Ok(Value::Obj(r));
+                    return Ok(Value::obj(r));
                 }
                 Err(VMError::new("unique() requires an array"))
             }
@@ -746,9 +749,9 @@ impl VM {
                         }
                     }
                     return Ok(if is_float {
-                        Value::Float(total_float)
+                        Value::float(total_float)
                     } else {
-                        Value::Int(total_int)
+                        Value::int(total_int, &mut self.gc)
                     });
                 }
                 Err(VMError::new("sum() requires an array"))
@@ -765,7 +768,7 @@ impl VM {
                         return Err(VMError::new("null array"));
                     };
                     if items.is_empty() {
-                        return Ok(Value::Null);
+                        return Ok(Value::null());
                     }
                     let mut min = items[0].clone();
                     for item in &items[1..] {
@@ -796,7 +799,7 @@ impl VM {
                         return Err(VMError::new("null array"));
                     };
                     if items.is_empty() {
-                        return Ok(Value::Null);
+                        return Ok(Value::null());
                     }
                     let mut max = items[0].clone();
                     for item in &items[1..] {
@@ -838,7 +841,7 @@ impl VM {
                     out.push(self.call_value(func.clone(), vec![item])?);
                 }
                 let r = self.gc.alloc(ObjKind::Array(out));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "filter" => {
                 if args.len() != 2 {
@@ -866,7 +869,7 @@ impl VM {
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(out));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "reduce" => {
                 if args.len() != 3 {
@@ -933,7 +936,7 @@ impl VM {
                                 return Err(e);
                             }
                             let nr = self.gc.alloc(ObjKind::Array(sorted));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                         // Default sort: ints, floats, strings
                         let mut sorted = items;
@@ -943,14 +946,14 @@ impl VM {
                                 x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal)
                             }
                             (Value::Obj(rx), Value::Obj(ry)) => {
-                                let sx = self.get_string(&Value::Obj(*rx)).unwrap_or_default();
-                                let sy = self.get_string(&Value::Obj(*ry)).unwrap_or_default();
+                                let sx = self.get_string(&Value::obj(*rx)).unwrap_or_default();
+                                let sy = self.get_string(&Value::obj(*ry)).unwrap_or_default();
                                 sx.cmp(&sy)
                             }
                             _ => std::cmp::Ordering::Equal,
                         });
                         let nr = self.gc.alloc(ObjKind::Array(sorted));
-                        return Ok(Value::Obj(nr));
+                        return Ok(Value::obj(nr));
                     }
                 }
                 Err(VMError::new("sort() requires an array"))
@@ -962,7 +965,7 @@ impl VM {
                             let mut rev = items.clone();
                             rev.reverse();
                             let nr = self.gc.alloc(ObjKind::Array(rev));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                     }
                 }
@@ -974,18 +977,18 @@ impl VM {
                         match &obj.kind {
                             ObjKind::String(s) => {
                                 let sub = val.display(&self.gc);
-                                return Ok(Value::Bool(s.contains(&sub)));
+                                return Ok(Value::bool_val(s.contains(&sub)));
                             }
                             ObjKind::Array(items) => {
                                 let found = items
                                     .iter()
                                     .any(|v| v.display(&self.gc) == val.display(&self.gc));
-                                return Ok(Value::Bool(found));
+                                return Ok(Value::bool_val(found));
                             }
                             _ => {}
                         }
                     }
-                    Ok(Value::Bool(false))
+                    Ok(Value::bool_val(false))
                 }
                 _ => Err(VMError::new("contains() requires (collection, value)")),
             },
@@ -999,7 +1002,7 @@ impl VM {
                             let keys: Vec<Value> =
                                 key_strings.iter().map(|k| self.alloc_string(k)).collect();
                             let nr = self.gc.alloc(ObjKind::Array(keys));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                     }
                 }
@@ -1011,7 +1014,7 @@ impl VM {
                         if let ObjKind::Object(map) = &obj.kind {
                             let vals: Vec<Value> = map.values().cloned().collect();
                             let nr = self.gc.alloc(ObjKind::Array(vals));
-                            return Ok(Value::Obj(nr));
+                            return Ok(Value::obj(nr));
                         }
                     }
                 }
@@ -1032,21 +1035,21 @@ impl VM {
                         let mut pairs = Vec::new();
                         for (idx, item) in items.iter().enumerate() {
                             let mut row = IndexMap::new();
-                            row.insert("index".to_string(), Value::Int(idx as i64));
+                            row.insert("index".to_string(), Value::small_int(idx as i64));
                             row.insert("value".to_string(), item.clone());
                             let rr = self.gc.alloc(ObjKind::Object(row));
-                            pairs.push(Value::Obj(rr));
+                            pairs.push(Value::obj(rr));
                         }
                         let nr = self.gc.alloc(ObjKind::Array(pairs));
-                        return Ok(Value::Obj(nr));
+                        return Ok(Value::obj(nr));
                     }
                 }
                 Err(VMError::new("enumerate() requires an array"))
             }
             "split" => {
                 if let (Some(Value::Obj(r1)), Some(Value::Obj(r2))) = (args.first(), args.get(1)) {
-                    let s = self.get_string(&Value::Obj(*r1)).unwrap_or_default();
-                    let delim = self.get_string(&Value::Obj(*r2)).unwrap_or_default();
+                    let s = self.get_string(&Value::obj(*r1)).unwrap_or_default();
+                    let delim = self.get_string(&Value::obj(*r2)).unwrap_or_default();
                     // Parity with interpreter: empty delimiter splits into individual chars
                     let parts: Vec<Value> = if delim.is_empty() {
                         s.chars()
@@ -1056,7 +1059,7 @@ impl VM {
                         s.split(&delim).map(|p| self.alloc_string(p)).collect()
                     };
                     let nr = self.gc.alloc(ObjKind::Array(parts));
-                    return Ok(Value::Obj(nr));
+                    return Ok(Value::obj(nr));
                 }
                 Err(VMError::new("split() requires (string, delimiter)"))
             }
@@ -1086,7 +1089,7 @@ impl VM {
                 if args.len() == 2 {
                     let s = args[0].display(&self.gc);
                     let prefix = args[1].display(&self.gc);
-                    return Ok(Value::Bool(s.starts_with(&prefix)));
+                    return Ok(Value::bool_val(s.starts_with(&prefix)));
                 }
                 Err(VMError::new("starts_with() requires (string, prefix)"))
             }
@@ -1094,7 +1097,7 @@ impl VM {
                 if args.len() == 2 {
                     let s = args[0].display(&self.gc);
                     let suffix = args[1].display(&self.gc);
-                    return Ok(Value::Bool(s.ends_with(&suffix)));
+                    return Ok(Value::bool_val(s.ends_with(&suffix)));
                 }
                 Err(VMError::new("ends_with() requires (string, suffix)"))
             }
@@ -1103,13 +1106,13 @@ impl VM {
                     self.sleep_with_timeout_checks(std::time::Duration::from_secs(
                         (*secs).max(0) as u64
                     ))?;
-                    Ok(Value::Null)
+                    Ok(Value::null())
                 }
                 Some(Value::Float(secs)) => {
                     self.sleep_with_timeout_checks(std::time::Duration::from_secs_f64(
                         secs.max(0.0),
                     ))?;
-                    Ok(Value::Null)
+                    Ok(Value::null())
                 }
                 _ => Err(VMError::new("wait() requires a number of seconds")),
             },
@@ -1142,16 +1145,16 @@ impl VM {
                                         .get("__variant__")
                                         .and_then(|v| self.get_string(v))
                                         .unwrap_or_default();
-                                    return Ok(Value::Bool(variant == "Some"));
+                                    return Ok(Value::bool_val(variant == "Some"));
                                 }
                                 // Non-Option object is truthy → Some
-                                return Ok(Value::Bool(true));
+                                return Ok(Value::bool_val(true));
                             }
                         }
-                        Ok(Value::Bool(true)) // non-null Obj is Some
+                        Ok(Value::bool_val(true)) // non-null Obj is Some
                     }
-                    Some(Value::Null) => Ok(Value::Bool(false)),
-                    Some(_) => Ok(Value::Bool(true)),
+                    Some(Value::Null) => Ok(Value::bool_val(false)),
+                    Some(_) => Ok(Value::bool_val(true)),
                     None => Err(VMError::new("is_some() requires an argument")),
                 }
             }
@@ -1170,15 +1173,15 @@ impl VM {
                                         .get("__variant__")
                                         .and_then(|v| self.get_string(v))
                                         .unwrap_or_default();
-                                    return Ok(Value::Bool(variant == "None"));
+                                    return Ok(Value::bool_val(variant == "None"));
                                 }
-                                return Ok(Value::Bool(false)); // non-Option object is Some
+                                return Ok(Value::bool_val(false)); // non-Option object is Some
                             }
                         }
-                        Ok(Value::Bool(false)) // non-null Obj is Some
+                        Ok(Value::bool_val(false)) // non-null Obj is Some
                     }
-                    Some(Value::Null) => Ok(Value::Bool(true)),
-                    Some(_) => Ok(Value::Bool(false)),
+                    Some(Value::Null) => Ok(Value::bool_val(true)),
+                    Some(_) => Ok(Value::bool_val(false)),
                     None => Err(VMError::new("is_none() requires an argument")),
                 }
             }
@@ -1188,7 +1191,7 @@ impl VM {
                 }
                 let method_names = self.interface_method_names(&args[1]);
                 if method_names.is_empty() {
-                    return Ok(Value::Bool(false));
+                    return Ok(Value::bool_val(false));
                 }
 
                 let structural = if let Some(map) = self.get_object_fields(&args[0]) {
@@ -1200,7 +1203,7 @@ impl VM {
                     false
                 };
                 if structural {
-                    return Ok(Value::Bool(true));
+                    return Ok(Value::bool_val(true));
                 }
 
                 if let Some(type_name) = self.value_type_name(&args[0]) {
@@ -1208,10 +1211,10 @@ impl VM {
                         let all_satisfied = method_names
                             .iter()
                             .all(|method_name| type_methods.contains_key(method_name));
-                        return Ok(Value::Bool(all_satisfied));
+                        return Ok(Value::bool_val(all_satisfied));
                     }
                 }
-                Ok(Value::Bool(false))
+                Ok(Value::bool_val(false))
             }
             n if n.starts_with("math.") => {
                 crate::stdlib::math::call_vm(n, &args, &self.gc).map_err(|e| VMError::new(&e))
@@ -1221,13 +1224,13 @@ impl VM {
                     crate::stdlib::fs::call_vm(n, &args, &self.gc).map_err(|e| VMError::new(&e))?;
                 match result {
                     crate::stdlib::fs::FsResult::StringVal(s) => Ok(self.alloc_string(&s)),
-                    crate::stdlib::fs::FsResult::BoolVal(b) => Ok(Value::Bool(b)),
+                    crate::stdlib::fs::FsResult::BoolVal(b) => Ok(Value::bool_val(b)),
                     crate::stdlib::fs::FsResult::ArrayVal(items) => {
                         let vals: Vec<Value> = items.iter().map(|s| self.alloc_string(s)).collect();
                         let r = self.gc.alloc(ObjKind::Array(vals));
-                        Ok(Value::Obj(r))
+                        Ok(Value::obj(r))
                     }
-                    crate::stdlib::fs::FsResult::NullVal => Ok(Value::Null),
+                    crate::stdlib::fs::FsResult::NullVal => Ok(Value::null()),
                 }
             }
             n if n.starts_with("io.") => {
@@ -1253,7 +1256,7 @@ impl VM {
                     crate::stdlib::crypto::call(n, str_args).map_err(|e| VMError::new(&e))?;
                 match result {
                     crate::interpreter::Value::String(s) => Ok(self.alloc_string(&s)),
-                    _ => Ok(Value::Null),
+                    _ => Ok(Value::null()),
                 }
             }
             n if n.starts_with("db.") => {
@@ -1274,8 +1277,8 @@ impl VM {
                     .collect();
                 let result = crate::stdlib::db::call(n, str_args).map_err(|e| VMError::new(&e))?;
                 match result {
-                    crate::interpreter::Value::Bool(b) => Ok(Value::Bool(b)),
-                    crate::interpreter::Value::Int(n) => Ok(Value::Int(n)),
+                    crate::interpreter::Value::Bool(b) => Ok(Value::bool_val(b)),
+                    crate::interpreter::Value::Int(n) => Ok(Value::int(n, &mut self.gc)),
                     crate::interpreter::Value::String(s) => Ok(self.alloc_string(&s)),
                     crate::interpreter::Value::Array(items) => {
                         let vm_items: Vec<Value> = items
@@ -1285,26 +1288,30 @@ impl VM {
                                     let mut vm_map = IndexMap::new();
                                     for (k, v) in map {
                                         let vm_v = match v {
-                                            crate::interpreter::Value::Int(n) => Value::Int(*n),
-                                            crate::interpreter::Value::Float(n) => Value::Float(*n),
+                                            crate::interpreter::Value::Int(n) => {
+                                                Value::int(*n, &mut self.gc)
+                                            }
+                                            crate::interpreter::Value::Float(n) => Value::float(*n),
                                             crate::interpreter::Value::String(s) => {
                                                 self.alloc_string(s)
                                             }
-                                            crate::interpreter::Value::Bool(b) => Value::Bool(*b),
-                                            _ => Value::Null,
+                                            crate::interpreter::Value::Bool(b) => {
+                                                Value::bool_val(*b)
+                                            }
+                                            _ => Value::null(),
                                         };
                                         vm_map.insert(k.clone(), vm_v);
                                     }
                                     let r = self.gc.alloc(ObjKind::Object(vm_map));
-                                    Value::Obj(r)
+                                    Value::obj(r)
                                 }
-                                _ => Value::Null,
+                                _ => Value::null(),
                             })
                             .collect();
                         let r = self.gc.alloc(ObjKind::Array(vm_items));
-                        Ok(Value::Obj(r))
+                        Ok(Value::obj(r))
                     }
-                    _ => Ok(Value::Null),
+                    _ => Ok(Value::null()),
                 }
             }
             n if n.starts_with("adt:") => {
@@ -1328,14 +1335,14 @@ impl VM {
                         obj.insert(format!("_{}", i), arg);
                     }
                     let r = self.gc.alloc(ObjKind::Object(obj));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 } else {
                     Err(VMError::new(&format!("invalid ADT constructor: {}", n)))
                 }
             }
             "fetch" => match args.first() {
                 Some(Value::Obj(r)) => {
-                    let url = self.get_string(&Value::Obj(*r)).unwrap_or_default();
+                    let url = self.get_string(&Value::obj(*r)).unwrap_or_default();
                     let method = "GET".to_string();
                     match crate::runtime::client::fetch_blocking(
                         &url, &method, None, None, None, None, None,
@@ -1359,7 +1366,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1378,7 +1385,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1396,7 +1403,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1417,7 +1424,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1435,7 +1442,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1456,7 +1463,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1474,7 +1481,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1485,14 +1492,14 @@ impl VM {
                     })
                     .collect();
                 crate::stdlib::log::call(n, interp_args).map_err(|e| VMError::new(&e))?;
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             n if n.starts_with("http.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else if let Some(obj) = self.gc.get(*r) {
                                 if let ObjKind::Object(map) = &obj.kind {
@@ -1523,7 +1530,7 @@ impl VM {
                     .iter()
                     .map(|v| match v {
                         Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::Obj(*r)) {
+                            if let Some(s) = self.get_string(&Value::obj(*r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1612,11 +1619,11 @@ impl VM {
                 map.insert("stderr".to_string(), self.alloc_string(&stderr));
                 map.insert(
                     "status".to_string(),
-                    Value::Int(output.status.code().unwrap_or(-1) as i64),
+                    Value::small_int(output.status.code().unwrap_or(-1) as i64),
                 );
-                map.insert("ok".to_string(), Value::Bool(output.status.success()));
+                map.insert("ok".to_string(), Value::bool_val(output.status.success()));
                 let r = self.gc.alloc(ObjKind::Object(map));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "sh" => {
                 crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
@@ -1647,7 +1654,7 @@ impl VM {
                     .map(|l| self.alloc_string(l))
                     .collect();
                 let r = self.gc.alloc(ObjKind::Array(lines));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "sh_json" => {
                 crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
@@ -1673,7 +1680,7 @@ impl VM {
                     .stderr(std::process::Stdio::null())
                     .status()
                     .map_err(|e| VMError::new(&format!("sh_ok error: {}", e)))?;
-                Ok(Value::Bool(status.success()))
+                Ok(Value::bool_val(status.success()))
             }
             "which" => {
                 let cmd = self.get_string_arg(&args, 0)?;
@@ -1683,7 +1690,7 @@ impl VM {
                 match result {
                     Ok(output) if output.status.success() => Ok(self
                         .alloc_string(&String::from_utf8_lossy(&output.stdout).trim().to_string())),
-                    _ => Ok(Value::Null),
+                    _ => Ok(Value::null()),
                 }
             }
             "cwd" => {
@@ -1701,7 +1708,7 @@ impl VM {
                 let text = self.get_string_arg(&args, 0)?;
                 let result: Vec<Value> = text.lines().map(|l| self.alloc_string(l)).collect();
                 let r = self.gc.alloc(ObjKind::Array(result));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "pipe_to" => {
                 crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
@@ -1741,27 +1748,27 @@ impl VM {
                 );
                 map.insert(
                     "status".to_string(),
-                    Value::Int(output.status.code().unwrap_or(-1) as i64),
+                    Value::small_int(output.status.code().unwrap_or(-1) as i64),
                 );
-                map.insert("ok".to_string(), Value::Bool(output.status.success()));
+                map.insert("ok".to_string(), Value::bool_val(output.status.success()));
                 let r = self.gc.alloc(ObjKind::Object(map));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "has_key" => {
                 if let (Some(Value::Obj(r)), Some(key_val)) = (args.first(), args.get(1)) {
                     let key = self.get_string(key_val).unwrap_or_default();
                     if let Some(obj) = self.gc.get(*r) {
                         if let ObjKind::Object(map) = &obj.kind {
-                            return Ok(Value::Bool(map.contains_key(&key)));
+                            return Ok(Value::bool_val(map.contains_key(&key)));
                         }
                     }
                 }
-                Ok(Value::Bool(false))
+                Ok(Value::bool_val(false))
             }
             "get" => {
                 if let (Some(Value::Obj(r)), Some(key_val)) = (args.first(), args.get(1)) {
                     let key = self.get_string(key_val).unwrap_or_default();
-                    let default = args.get(2).cloned().unwrap_or(Value::Null);
+                    let default = args.get(2).cloned().unwrap_or(Value::null());
                     if let Some(obj) = self.gc.get(*r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             if key.contains('.') {
@@ -1792,7 +1799,7 @@ impl VM {
                     }
                     Ok(default)
                 } else {
-                    Ok(Value::Null)
+                    Ok(Value::null())
                 }
             }
             "pick" => {
@@ -1818,9 +1825,9 @@ impl VM {
                         }
                     }
                     let r = self.gc.alloc(ObjKind::Object(result));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 } else {
-                    Ok(Value::Null)
+                    Ok(Value::null())
                 }
             }
             "omit" => {
@@ -1846,9 +1853,9 @@ impl VM {
                         }
                     }
                     let r = self.gc.alloc(ObjKind::Object(result));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 } else {
-                    Ok(Value::Null)
+                    Ok(Value::null())
                 }
             }
             "merge" => {
@@ -1865,7 +1872,7 @@ impl VM {
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Object(result));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "entries" => {
                 if let Some(Value::Obj(r)) = args.first() {
@@ -1883,10 +1890,10 @@ impl VM {
                     for (k, v) in kv_pairs {
                         let key = self.alloc_string(&k);
                         let pair_r = self.gc.alloc(ObjKind::Array(vec![key, v]));
-                        pairs.push(Value::Obj(pair_r));
+                        pairs.push(Value::obj(pair_r));
                     }
                     let r = self.gc.alloc(ObjKind::Array(pairs));
-                    return Ok(Value::Obj(r));
+                    return Ok(Value::obj(r));
                 }
                 Err(VMError::new("entries() requires an object"))
             }
@@ -1910,11 +1917,11 @@ impl VM {
                                 }
                             }
                             let r = self.gc.alloc(ObjKind::Object(result));
-                            return Ok(Value::Obj(r));
+                            return Ok(Value::obj(r));
                         }
                     }
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "find" => {
                 // find(array, predicate) -> first matching element or Null
@@ -1941,7 +1948,7 @@ impl VM {
                         return Ok(item);
                     }
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "flat_map" => {
                 // flat_map(array, function) -> flattened array
@@ -1973,13 +1980,13 @@ impl VM {
                                     continue;
                                 }
                             }
-                            out.push(Value::Obj(r));
+                            out.push(Value::obj(r));
                         }
                         other => out.push(other),
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(out));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             // ===== typeof (alias for "type") =====
             "typeof" => match args.first() {
@@ -1997,7 +2004,7 @@ impl VM {
                         .ok_or_else(|| VMError::new("first() requires an array"))?,
                     "first() requires an array",
                 )?;
-                Ok(items.first().cloned().unwrap_or(Value::Null))
+                Ok(items.first().cloned().unwrap_or(Value::null()))
             }
             "last" => {
                 let items = self.array_items(
@@ -2005,7 +2012,7 @@ impl VM {
                         .ok_or_else(|| VMError::new("last() requires an array"))?,
                     "last() requires an array",
                 )?;
-                Ok(items.last().cloned().unwrap_or(Value::Null))
+                Ok(items.last().cloned().unwrap_or(Value::null()))
             }
             "zip" => {
                 if args.len() < 2 {
@@ -2018,11 +2025,11 @@ impl VM {
                     .zip(b.into_iter())
                     .map(|(x, y)| {
                         let pair = self.gc.alloc(ObjKind::Array(vec![x, y]));
-                        Value::Obj(pair)
+                        Value::obj(pair)
                     })
                     .collect();
                 let r = self.gc.alloc(ObjKind::Array(pairs));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "flatten" => {
                 let items = self.array_items(
@@ -2046,7 +2053,7 @@ impl VM {
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(result));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "chunk" => {
                 if args.len() < 2 {
@@ -2061,11 +2068,11 @@ impl VM {
                     .chunks(size)
                     .map(|c| {
                         let arr = self.gc.alloc(ObjKind::Array(c.to_vec()));
-                        Value::Obj(arr)
+                        Value::obj(arr)
                     })
                     .collect();
                 let r = self.gc.alloc(ObjKind::Array(chunks));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "slice" => {
                 let first = args
@@ -2125,10 +2132,10 @@ impl VM {
                 };
                 if start >= end || start >= items.len() {
                     let r = self.gc.alloc(ObjKind::Array(vec![]));
-                    return Ok(Value::Obj(r));
+                    return Ok(Value::obj(r));
                 }
                 let r = self.gc.alloc(ObjKind::Array(items[start..end].to_vec()));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "compact" => {
                 let items = self.array_items(
@@ -2141,7 +2148,7 @@ impl VM {
                     .filter(|v| !matches!(v, Value::Null | Value::Bool(false)))
                     .collect();
                 let r = self.gc.alloc(ObjKind::Array(filtered));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "partition" => {
                 if args.len() < 2 {
@@ -2162,10 +2169,10 @@ impl VM {
                 let matches_r = self.gc.alloc(ObjKind::Array(matches));
                 let rest_r = self.gc.alloc(ObjKind::Array(rest));
                 let r = self.gc.alloc(ObjKind::Array(vec![
-                    Value::Obj(matches_r),
-                    Value::Obj(rest_r),
+                    Value::obj(matches_r),
+                    Value::obj(rest_r),
                 ]));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "group_by" => {
                 if args.len() < 2 {
@@ -2182,10 +2189,10 @@ impl VM {
                 let mut result = IndexMap::new();
                 for (k, v) in groups {
                     let arr = self.gc.alloc(ObjKind::Array(v));
-                    result.insert(k, Value::Obj(arr));
+                    result.insert(k, Value::obj(arr));
                 }
                 let r = self.gc.alloc(ObjKind::Object(result));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "sort_by" => {
                 if args.len() < 2 {
@@ -2218,7 +2225,7 @@ impl VM {
                 });
                 let sorted: Vec<Value> = pairs.into_iter().map(|(_, v)| v).collect();
                 let r = self.gc.alloc(ObjKind::Array(sorted));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "for_each" => {
                 if args.len() < 2 {
@@ -2229,7 +2236,7 @@ impl VM {
                 for item in items {
                     self.call_value(func.clone(), vec![item])?;
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "take_n" => {
                 if args.len() < 2 {
@@ -2241,7 +2248,7 @@ impl VM {
                     _ => return Err(VMError::new("take_n() second arg must be int")),
                 };
                 let r = self.gc.alloc(ObjKind::Array(items[..n].to_vec()));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "skip" => {
                 if args.len() < 2 {
@@ -2253,7 +2260,7 @@ impl VM {
                     _ => return Err(VMError::new("skip() second arg must be int")),
                 };
                 let r = self.gc.alloc(ObjKind::Array(items[n..].to_vec()));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "frequencies" => {
                 let items = self.array_items(
@@ -2274,10 +2281,10 @@ impl VM {
                             }
                         })
                         .unwrap_or(0);
-                    counts.insert(key, Value::Int(count + 1));
+                    counts.insert(key, Value::small_int(count + 1));
                 }
                 let r = self.gc.alloc(ObjKind::Object(counts));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
 
             // ===== String builtins =====
@@ -2304,7 +2311,9 @@ impl VM {
                 // String case
                 if let Some(s) = self.get_string(first) {
                     let substr = self.get_string_arg(&args, 1)?;
-                    return Ok(Value::Int(s.find(&substr).map(|i| i as i64).unwrap_or(-1)));
+                    return Ok(Value::small_int(
+                        s.find(&substr).map(|i| i as i64).unwrap_or(-1),
+                    ));
                 }
                 // Array case
                 let items = self.array_items(first, "index_of() requires a string or array")?;
@@ -2312,12 +2321,14 @@ impl VM {
                     .get(1)
                     .ok_or_else(|| VMError::new("index_of() requires 2 arguments"))?;
                 let idx = items.iter().position(|v| v.equals(needle, &self.gc));
-                Ok(Value::Int(idx.map(|i| i as i64).unwrap_or(-1)))
+                Ok(Value::small_int(idx.map(|i| i as i64).unwrap_or(-1)))
             }
             "last_index_of" => {
                 let s = self.get_string_arg(&args, 0)?;
                 let substr = self.get_string_arg(&args, 1)?;
-                Ok(Value::Int(s.rfind(&substr).map(|i| i as i64).unwrap_or(-1)))
+                Ok(Value::small_int(
+                    s.rfind(&substr).map(|i| i as i64).unwrap_or(-1),
+                ))
             }
             "capitalize" => {
                 let s = self.get_string_arg(&args, 0)?;
@@ -2436,9 +2447,9 @@ impl VM {
                 let s = self.get_string_arg(&args, 0)?;
                 let substr = self.get_string_arg(&args, 1)?;
                 if substr.is_empty() {
-                    return Ok(Value::Int((s.chars().count() + 1) as i64));
+                    return Ok(Value::small_int((s.chars().count() + 1) as i64));
                 }
-                Ok(Value::Int(s.matches(&*substr).count() as i64))
+                Ok(Value::small_int(s.matches(&*substr).count() as i64))
             }
             "slugify" => {
                 let s = self.get_string_arg(&args, 0)?;
@@ -2514,7 +2525,7 @@ impl VM {
                 };
                 if items.is_empty() {
                     let r = self.gc.alloc(ObjKind::Array(vec![]));
-                    return Ok(Value::Obj(r));
+                    return Ok(Value::obj(r));
                 }
                 use std::time::{SystemTime, UNIX_EPOCH};
                 let seed = SystemTime::now()
@@ -2531,10 +2542,10 @@ impl VM {
                     result.push(items[idx].clone());
                 }
                 if n == 1 {
-                    Ok(result.into_iter().next().unwrap_or(Value::Null))
+                    Ok(result.into_iter().next().unwrap_or(Value::null()))
                 } else {
                     let r = self.gc.alloc(ObjKind::Array(result));
-                    Ok(Value::Obj(r))
+                    Ok(Value::obj(r))
                 }
             }
             "shuffle" => {
@@ -2556,7 +2567,7 @@ impl VM {
                     items.swap(i, j);
                 }
                 let r = self.gc.alloc(ObjKind::Array(items));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "input" => {
                 use std::io::Read as _;
@@ -2660,7 +2671,7 @@ impl VM {
                 }
                 let func = args[0].clone();
                 match self.call_value(func, vec![]) {
-                    Err(_) => Ok(Value::Bool(true)),
+                    Err(_) => Ok(Value::bool_val(true)),
                     Ok(_) => Err(VMError::new(
                         "assertion failed: expected function to throw an error, but it succeeded",
                     )),
@@ -2679,7 +2690,7 @@ impl VM {
                     "\x1b[33m\u{1f50d} SUS CHECK:\x1b[0m {} \x1b[2m({})\x1b[0m",
                     display, type_str
                 );
-                Ok(args.into_iter().next().unwrap_or(Value::Null))
+                Ok(args.into_iter().next().unwrap_or(Value::null()))
             }
             "bruh" => {
                 let msg = args
@@ -2695,7 +2706,7 @@ impl VM {
                     None => return Err(VMError::new("bet() needs a condition, no cap")),
                 };
                 if condition {
-                    Ok(Value::Bool(true))
+                    Ok(Value::bool_val(true))
                 } else {
                     let msg = args
                         .get(1)
@@ -2709,7 +2720,7 @@ impl VM {
                     return Err(VMError::new("no_cap() needs two values to compare, fr fr"));
                 }
                 if args[0].equals(&args[1], &self.gc) {
-                    Ok(Value::Bool(true))
+                    Ok(Value::bool_val(true))
                 } else {
                     let a = args[0].display(&self.gc);
                     let b = args[1].display(&self.gc);
@@ -2723,7 +2734,7 @@ impl VM {
                     None => return Err(VMError::new("ick() needs a condition to reject")),
                 };
                 if !condition {
-                    Ok(Value::Bool(true))
+                    Ok(Value::bool_val(true))
                 } else {
                     let msg = args
                         .get(1)
@@ -2766,7 +2777,7 @@ impl VM {
                 let func = args[0].clone();
                 match self.call_value(func, vec![]) {
                     Ok(val) => Ok(val),
-                    Err(_) => Ok(Value::Null),
+                    Err(_) => Ok(Value::null()),
                 }
             }
             "ghost" => {
@@ -2787,7 +2798,7 @@ impl VM {
                     _ => 100,
                 };
                 let mut times: Vec<f64> = Vec::with_capacity(n);
-                let mut last_result = Value::Null;
+                let mut last_result = Value::null();
                 for _ in 0..n {
                     let start = std::time::Instant::now();
                     last_result = self.call_value(func.clone(), vec![])?;
@@ -2803,18 +2814,18 @@ impl VM {
                     .copied()
                     .unwrap_or(0.0);
                 let mut stats = IndexMap::new();
-                stats.insert("avg_ms".to_string(), Value::Float(avg));
-                stats.insert("min_ms".to_string(), Value::Float(min_t));
-                stats.insert("max_ms".to_string(), Value::Float(max_t));
-                stats.insert("p99_ms".to_string(), Value::Float(p99));
-                stats.insert("runs".to_string(), Value::Int(n as i64));
+                stats.insert("avg_ms".to_string(), Value::float(avg));
+                stats.insert("min_ms".to_string(), Value::float(min_t));
+                stats.insert("max_ms".to_string(), Value::float(max_t));
+                stats.insert("p99_ms".to_string(), Value::float(p99));
+                stats.insert("runs".to_string(), Value::small_int(n as i64));
                 stats.insert("result".to_string(), last_result);
                 eprintln!(
                     "\x1b[35m\u{1f485} SLAYED:\x1b[0m {}x runs \u{2014} avg {:.3}ms, min {:.3}ms, max {:.3}ms, p99 {:.3}ms",
                     n, avg, min_t, max_t, p99
                 );
                 let r = self.gc.alloc(ObjKind::Object(stats));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
 
             // ----- Channel builtins -----
@@ -2835,7 +2846,7 @@ impl VM {
                     receiver: std::sync::Mutex::new(Some(receiver)),
                 });
                 let r = self.gc.alloc(ObjKind::Channel(inner));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "send" => {
                 if args.len() < 2 {
@@ -2857,7 +2868,7 @@ impl VM {
                         return Err(VMError::new("channel closed"));
                     }
                 }
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "receive" => {
                 if args.is_empty() {
@@ -2868,9 +2879,9 @@ impl VM {
                 match &*guard {
                     Some(rx) => match rx.recv() {
                         Ok(shared) => Ok(shared_to_value(&mut self.gc, &shared)),
-                        Err(_) => Ok(Value::Null),
+                        Err(_) => Ok(Value::null()),
                     },
-                    None => Ok(Value::Null),
+                    None => Ok(Value::null()),
                 }
             }
             "close" => {
@@ -2880,7 +2891,7 @@ impl VM {
                 let ch_arc = self.extract_channel(&args[0])?;
                 let mut guard = ch_arc.sender.lock().unwrap_or_else(|e| e.into_inner());
                 *guard = None;
-                Ok(Value::Null)
+                Ok(Value::null())
             }
             "try_send" => {
                 if args.len() < 2 {
@@ -2895,7 +2906,7 @@ impl VM {
                     Some(VmChannelSender::Unbounded(tx)) => tx.send(shared).is_ok(),
                     None => false,
                 };
-                Ok(Value::Bool(ok))
+                Ok(Value::bool_val(ok))
             }
             "try_receive" => {
                 if args.is_empty() {
@@ -2908,11 +2919,11 @@ impl VM {
                         Ok(shared) => {
                             let val = shared_to_value(&mut self.gc, &shared);
                             let r = self.gc.alloc(ObjKind::ResultOk(val));
-                            Ok(Value::Obj(r))
+                            Ok(Value::obj(r))
                         }
-                        Err(_) => Ok(Value::Null),
+                        Err(_) => Ok(Value::null()),
                     },
-                    None => Ok(Value::Null),
+                    None => Ok(Value::null()),
                 }
             }
             "select" => {
@@ -2939,7 +2950,7 @@ impl VM {
                     _ => return Err(VMError::new("select() requires an array of channels")),
                 };
                 if channels.is_empty() {
-                    return Ok(Value::Null);
+                    return Ok(Value::null());
                 }
                 let timeout_ms: Option<u128> = match args.get(1) {
                     Some(Value::Int(ms)) => Some((*ms).max(0) as u128),
@@ -2961,9 +2972,9 @@ impl VM {
                             match rx.try_recv() {
                                 Ok(shared) => {
                                     let val = shared_to_value(&mut self.gc, &shared);
-                                    let idx_val = Value::Int(idx as i64);
+                                    let idx_val = Value::small_int(idx as i64);
                                     let arr = self.gc.alloc(ObjKind::Array(vec![idx_val, val]));
-                                    return Ok(Value::Obj(arr));
+                                    return Ok(Value::obj(arr));
                                 }
                                 Err(std::sync::mpsc::TryRecvError::Empty) => {
                                     all_closed = false;
@@ -2975,11 +2986,11 @@ impl VM {
                         }
                     }
                     if all_closed {
-                        return Ok(Value::Null);
+                        return Ok(Value::null());
                     }
                     if let Some(ms) = timeout_ms {
                         if start.elapsed().as_millis() >= ms {
-                            return Ok(Value::Null);
+                            return Ok(Value::null());
                         }
                     }
                     offset = (offset + 1) % len;
@@ -2991,14 +3002,20 @@ impl VM {
                 let now = Utc::now();
                 let mut m = IndexMap::new();
                 m.insert("iso".to_string(), self.alloc_string(&now.to_rfc3339()));
-                m.insert("unix".to_string(), Value::Int(now.timestamp()));
-                m.insert("unix_ms".to_string(), Value::Int(now.timestamp_millis()));
-                m.insert("year".to_string(), Value::Int(now.year() as i64));
-                m.insert("month".to_string(), Value::Int(now.month() as i64));
-                m.insert("day".to_string(), Value::Int(now.day() as i64));
-                m.insert("hour".to_string(), Value::Int(now.hour() as i64));
-                m.insert("minute".to_string(), Value::Int(now.minute() as i64));
-                m.insert("second".to_string(), Value::Int(now.second() as i64));
+                m.insert(
+                    "unix".to_string(),
+                    Value::int(now.timestamp(), &mut self.gc),
+                );
+                m.insert(
+                    "unix_ms".to_string(),
+                    Value::int(now.timestamp_millis(), &mut self.gc),
+                );
+                m.insert("year".to_string(), Value::small_int(now.year() as i64));
+                m.insert("month".to_string(), Value::small_int(now.month() as i64));
+                m.insert("day".to_string(), Value::small_int(now.day() as i64));
+                m.insert("hour".to_string(), Value::small_int(now.hour() as i64));
+                m.insert("minute".to_string(), Value::small_int(now.minute() as i64));
+                m.insert("second".to_string(), Value::small_int(now.second() as i64));
                 m.insert(
                     "weekday".to_string(),
                     self.alloc_string(&now.format("%A").to_string()),
@@ -3007,10 +3024,13 @@ impl VM {
                     "weekday_short".to_string(),
                     self.alloc_string(&now.format("%a").to_string()),
                 );
-                m.insert("day_of_year".to_string(), Value::Int(now.ordinal() as i64));
+                m.insert(
+                    "day_of_year".to_string(),
+                    Value::small_int(now.ordinal() as i64),
+                );
                 m.insert("timezone".to_string(), self.alloc_string("UTC"));
                 let r = self.gc.alloc(ObjKind::Object(m));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "await_all" => {
                 if args.is_empty() {
@@ -3076,7 +3096,7 @@ impl VM {
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(results));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             "await_timeout" => {
                 if args.len() < 2 {
@@ -3104,7 +3124,7 @@ impl VM {
                             loop {
                                 let remaining = deadline.saturating_sub(start.elapsed());
                                 if remaining.is_zero() {
-                                    return Ok(Value::Null);
+                                    return Ok(Value::null());
                                 }
                                 let (g, timeout_result) = cvar
                                     .wait_timeout(guard, remaining)
@@ -3114,7 +3134,7 @@ impl VM {
                                     break;
                                 }
                                 if timeout_result.timed_out() {
-                                    return Ok(Value::Null);
+                                    return Ok(Value::null());
                                 }
                             }
                         }
@@ -3172,7 +3192,7 @@ impl VM {
         marker.insert("__kind__".to_string(), self.alloc_string("struct"));
         marker.insert("name".to_string(), self.alloc_string(type_name));
         let r = self.gc.alloc(ObjKind::Object(marker));
-        Value::Obj(r)
+        Value::obj(r)
     }
 
     fn extract_channel(&self, val: &Value) -> Result<Arc<VmChannelInner>, VMError> {

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -96,8 +96,8 @@ impl VM {
                 }
                 let type_name = self.get_string_arg(&args, 0)?;
                 let method_name = self.get_string_arg(&args, 1)?;
-                let has_receiver = match args[2] {
-                    Value::Bool(flag) => flag,
+                let has_receiver = match args[2].as_bool() {
+                    Some(flag) => flag,
                     _ => {
                         return Err(VMError::new(
                             "__forge_register_method() third argument must be Bool",
@@ -182,19 +182,20 @@ impl VM {
                 if args.len() != 1 {
                     return Err(VMError::new("__forge_retry_count() requires (count)"));
                 }
-                match args[0] {
-                    Value::Int(n) => Ok(Value::small_int(n.max(0))),
-                    _ => Ok(Value::small_int(3)),
+                if let Some(n) = args[0].as_int(&self.gc) {
+                    Ok(Value::small_int(n.max(0)))
+                } else {
+                    Ok(Value::small_int(3))
                 }
             }
             "__forge_retry_wait" => {
                 if args.len() != 1 {
                     return Err(VMError::new("__forge_retry_wait() requires (attempt)"));
                 }
-                let attempt = match args[0] {
-                    Value::Int(n) => n.max(0) as u64,
-                    _ => 0,
-                };
+                let attempt = args[0]
+                    .as_int(&self.gc)
+                    .map(|n| n.max(0) as u64)
+                    .unwrap_or(0);
                 if attempt > 0 {
                     std::thread::sleep(std::time::Duration::from_millis(100 * attempt));
                 }
@@ -206,21 +207,21 @@ impl VM {
                         "__forge_retry_failed() requires (count, last_error)",
                     ));
                 }
-                let count = match args[0] {
-                    Value::Int(n) => n.max(0),
+                let count = match args[0].classify(&self.gc) {
+                    ValueKind::Int(n) => n.max(0),
                     _ => 0,
                 };
-                let last_error = match &args[1] {
-                    Value::Obj(r) => self
+                let last_error = match args[1].classify(&self.gc) {
+                    ValueKind::Obj(r) => self
                         .gc
-                        .get(*r)
+                        .get(r)
                         .and_then(|obj| match &obj.kind {
                             ObjKind::Object(map) => map.get("message").cloned(),
                             _ => None,
                         })
                         .map(|value| value.display(&self.gc))
                         .unwrap_or_default(),
-                    value => value.display(&self.gc),
+                    _ => args[1].display(&self.gc),
                 };
                 Err(VMError::new(&format!(
                     "retry failed after {} attempts: {}",
@@ -278,9 +279,9 @@ impl VM {
                 }
                 let items =
                     self.array_items(&args[0], "__forge_pipe_take() first arg must be array")?;
-                let count = match args[1] {
-                    Value::Int(n) => n.max(0) as usize,
-                    Value::Float(n) => n.max(0.0) as usize,
+                let count = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) => n.max(0) as usize,
+                    ValueKind::Float(n) => n.max(0.0) as usize,
                     _ => 10,
                 };
                 let r = self
@@ -292,17 +293,17 @@ impl VM {
                 if args.len() != 1 {
                     return Err(VMError::new("__forge_raise_error() requires (error)"));
                 }
-                let message = match &args[0] {
-                    Value::Obj(r) => self
+                let message = match args[0].classify(&self.gc) {
+                    ValueKind::Obj(r) => self
                         .gc
-                        .get(*r)
+                        .get(r)
                         .and_then(|obj| match &obj.kind {
                             ObjKind::Object(map) => map.get("message").cloned(),
                             _ => None,
                         })
                         .map(|value| value.display(&self.gc))
                         .unwrap_or_else(|| args[0].display(&self.gc)),
-                    value => value.display(&self.gc),
+                    _ => args[0].display(&self.gc),
                 };
                 Err(VMError::new(&message))
             }
@@ -313,10 +314,10 @@ impl VM {
                     ));
                 }
 
-                let requested_names = match args.get(1) {
-                    Some(Value::Obj(r)) => self
+                let requested_names = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Obj(r)) => self
                         .gc
-                        .get(*r)
+                        .get(r)
                         .and_then(|obj| match &obj.kind {
                             ObjKind::Array(items) => Some(
                                 items.iter()
@@ -330,7 +331,7 @@ impl VM {
                                 "__forge_import_module() second argument must be an array of strings",
                             )
                         })?,
-                    Some(Value::Null) | None => Vec::new(),
+                    Some(ValueKind::Null) | None => Vec::new(),
                     Some(_) => {
                         return Err(VMError::new(
                             "__forge_import_module() second argument must be an array of strings",
@@ -412,14 +413,15 @@ impl VM {
             }
             "len" => match args.first() {
                 Some(v) => {
-                    let len = match v {
-                        Value::Obj(r) => self.gc.get(*r).map_or(0, |o| match &o.kind {
+                    let len = if let Some(r) = v.as_obj() {
+                        self.gc.get(r).map_or(0, |o| match &o.kind {
                             ObjKind::String(s) => s.chars().count() as i64,
                             ObjKind::Array(a) => a.len() as i64,
                             ObjKind::Object(o) => o.len() as i64,
                             _ => 0,
-                        }),
-                        _ => 0,
+                        })
+                    } else {
+                        0
                     };
                     Ok(Value::small_int(len))
                 }
@@ -439,13 +441,13 @@ impl VM {
                     .unwrap_or_default();
                 Ok(self.alloc_string(&s))
             }
-            "int" => match args.first() {
-                Some(Value::Int(n)) => Ok(Value::int(*n, &mut self.gc)),
-                Some(Value::Float(n)) => Ok(Value::int(*n as i64, &mut self.gc)),
+            "int" => match args.first().map(|v| v.classify(&self.gc)) {
+                Some(ValueKind::Int(n)) => Ok(Value::int(n, &mut self.gc)),
+                Some(ValueKind::Float(n)) => Ok(Value::int(n as i64, &mut self.gc)),
                 // Parity with interpreter: bool → 0/1
-                Some(Value::Bool(b)) => Ok(Value::small_int(if *b { 1 } else { 0 })),
-                Some(Value::Obj(r)) => {
-                    let s_owned = self.gc.get(*r).and_then(|obj| match &obj.kind {
+                Some(ValueKind::Bool(b)) => Ok(Value::small_int(if b { 1 } else { 0 })),
+                Some(ValueKind::Obj(r)) => {
+                    let s_owned = self.gc.get(r).and_then(|obj| match &obj.kind {
                         ObjKind::String(s) => Some(s.clone()),
                         _ => None,
                     });
@@ -459,12 +461,12 @@ impl VM {
                 }
                 _ => Err(VMError::new("int() requires number, bool, or string")),
             },
-            "float" => match args.first() {
-                Some(Value::Int(n)) => Ok(Value::float(*n as f64)),
-                Some(Value::Float(n)) => Ok(Value::float(*n)),
+            "float" => match args.first().map(|v| v.classify(&self.gc)) {
+                Some(ValueKind::Int(n)) => Ok(Value::float(n as f64)),
+                Some(ValueKind::Float(n)) => Ok(Value::float(n)),
                 // Parity with interpreter: parse string to float
-                Some(Value::Obj(r)) => {
-                    if let Some(obj) = self.gc.get(*r) {
+                Some(ValueKind::Obj(r)) => {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::String(s) = &obj.kind {
                             return s.parse::<f64>().map(Value::float).map_err(|_| {
                                 VMError::new(&format!("cannot convert '{}' to Float", s))
@@ -475,14 +477,17 @@ impl VM {
                 }
                 _ => Err(VMError::new("float() requires a number or numeric string")),
             },
-            "range" => match (args.first(), args.get(1)) {
-                (Some(Value::Int(start)), Some(Value::Int(end))) => {
-                    let items: Vec<Value> = (*start..*end).map(Value::Int).collect();
+            "range" => match (
+                args.first().and_then(|v| v.as_int(&self.gc)),
+                args.get(1).and_then(|v| v.as_int(&self.gc)),
+            ) {
+                (Some(start), Some(end)) => {
+                    let items: Vec<Value> = (start..end).map(Value::small_int).collect();
                     let r = self.gc.alloc(ObjKind::Array(items));
                     Ok(Value::obj(r))
                 }
-                (Some(Value::Int(end_val)), None) => {
-                    let items: Vec<Value> = (0..*end_val).map(Value::Int).collect();
+                (Some(end_val), None) => {
+                    let items: Vec<Value> = (0..end_val).map(Value::small_int).collect();
                     let r = self.gc.alloc(ObjKind::Array(items));
                     Ok(Value::obj(r))
                 }
@@ -492,8 +497,8 @@ impl VM {
                 if args.len() != 2 {
                     return Err(VMError::new("push() requires array and value"));
                 }
-                if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             let mut new_items = items.clone();
                             new_items.push(args[1].clone());
@@ -505,8 +510,8 @@ impl VM {
                 Err(VMError::new("push() requires an array"))
             }
             "pop" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             let mut new_items = items.clone();
                             new_items.pop();
@@ -555,24 +560,24 @@ impl VM {
                 Ok(Value::obj(r))
             }
             "is_ok" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         return Ok(Value::bool_val(matches!(obj.kind, ObjKind::ResultOk(_))));
                     }
                 }
                 Ok(Value::bool_val(false))
             }
             "is_err" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         return Ok(Value::bool_val(matches!(obj.kind, ObjKind::ResultErr(_))));
                     }
                 }
                 Ok(Value::bool_val(false))
             }
             "unwrap" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::ResultOk(v) = &obj.kind {
                             return Ok(v.clone());
                         }
@@ -590,8 +595,8 @@ impl VM {
                 if args.len() < 2 {
                     return Err(VMError::new("unwrap_or() requires 2 args"));
                 }
-                if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::ResultOk(v) = &obj.kind {
                             return Ok(v.clone());
                         }
@@ -644,8 +649,8 @@ impl VM {
                 if args.len() < 2 {
                     return Err(VMError::new("any() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -672,8 +677,8 @@ impl VM {
                 if args.len() < 2 {
                     return Err(VMError::new("all() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -697,8 +702,8 @@ impl VM {
                 Ok(Value::bool_val(true))
             }
             "unique" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -722,8 +727,8 @@ impl VM {
                 Err(VMError::new("unique() requires an array"))
             }
             "sum" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -736,12 +741,12 @@ impl VM {
                     let mut total_float: f64 = 0.0;
                     let mut is_float = false;
                     for item in &items {
-                        match item {
-                            Value::Int(n) => {
+                        match item.classify(&self.gc) {
+                            ValueKind::Int(n) => {
                                 total_int += n;
-                                total_float += *n as f64;
+                                total_float += n as f64;
                             }
-                            Value::Float(n) => {
+                            ValueKind::Float(n) => {
                                 total_float += n;
                                 is_float = true;
                             }
@@ -757,8 +762,8 @@ impl VM {
                 Err(VMError::new("sum() requires an array"))
             }
             "min_of" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -772,11 +777,11 @@ impl VM {
                     }
                     let mut min = items[0].clone();
                     for item in &items[1..] {
-                        let less = match (&min, item) {
-                            (Value::Int(a), Value::Int(b)) => b < a,
-                            (Value::Float(a), Value::Float(b)) => b < a,
-                            (Value::Int(a), Value::Float(b)) => b < &(*a as f64),
-                            (Value::Float(a), Value::Int(b)) => (*b as f64) < *a,
+                        let less = match (min.classify(&self.gc), item.classify(&self.gc)) {
+                            (ValueKind::Int(a), ValueKind::Int(b)) => b < a,
+                            (ValueKind::Float(a), ValueKind::Float(b)) => b < a,
+                            (ValueKind::Int(a), ValueKind::Float(b)) => b < (a as f64),
+                            (ValueKind::Float(a), ValueKind::Int(b)) => (b as f64) < a,
                             _ => false,
                         };
                         if less {
@@ -788,8 +793,8 @@ impl VM {
                 Err(VMError::new("min_of() requires an array"))
             }
             "max_of" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -803,11 +808,11 @@ impl VM {
                     }
                     let mut max = items[0].clone();
                     for item in &items[1..] {
-                        let greater = match (&max, item) {
-                            (Value::Int(a), Value::Int(b)) => b > a,
-                            (Value::Float(a), Value::Float(b)) => b > a,
-                            (Value::Int(a), Value::Float(b)) => b > &(*a as f64),
-                            (Value::Float(a), Value::Int(b)) => (*b as f64) > *a,
+                        let greater = match (max.classify(&self.gc), item.classify(&self.gc)) {
+                            (ValueKind::Int(a), ValueKind::Int(b)) => b > a,
+                            (ValueKind::Float(a), ValueKind::Float(b)) => b > a,
+                            (ValueKind::Int(a), ValueKind::Float(b)) => b > (a as f64),
+                            (ValueKind::Float(a), ValueKind::Int(b)) => (b as f64) > a,
                             _ => false,
                         };
                         if greater {
@@ -822,8 +827,8 @@ impl VM {
                 if args.len() != 2 {
                     return Err(VMError::new("map() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -847,8 +852,8 @@ impl VM {
                 if args.len() != 2 {
                     return Err(VMError::new("filter() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -875,8 +880,8 @@ impl VM {
                 if args.len() != 3 {
                     return Err(VMError::new("reduce() requires (array, initial, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -896,8 +901,8 @@ impl VM {
                 Ok(acc)
             }
             "sort" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items_clone = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items_clone = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             Some(a.clone())
                         } else {
@@ -916,16 +921,18 @@ impl VM {
                                     return std::cmp::Ordering::Equal;
                                 }
                                 match self.call_value(func.clone(), vec![a.clone(), b.clone()]) {
-                                    Ok(Value::Int(n)) => {
-                                        if n < 0 {
-                                            std::cmp::Ordering::Less
-                                        } else if n > 0 {
-                                            std::cmp::Ordering::Greater
-                                        } else {
-                                            std::cmp::Ordering::Equal
+                                    Ok(ref v) => match v.as_int(&self.gc) {
+                                        Some(n) => {
+                                            if n < 0 {
+                                                std::cmp::Ordering::Less
+                                            } else if n > 0 {
+                                                std::cmp::Ordering::Greater
+                                            } else {
+                                                std::cmp::Ordering::Equal
+                                            }
                                         }
-                                    }
-                                    Ok(_) => std::cmp::Ordering::Equal,
+                                        None => std::cmp::Ordering::Equal,
+                                    },
                                     Err(e) => {
                                         err = Some(e);
                                         std::cmp::Ordering::Equal
@@ -940,14 +947,14 @@ impl VM {
                         }
                         // Default sort: ints, floats, strings
                         let mut sorted = items;
-                        sorted.sort_by(|a, b| match (a, b) {
-                            (Value::Int(x), Value::Int(y)) => x.cmp(y),
-                            (Value::Float(x), Value::Float(y)) => {
-                                x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal)
+                        sorted.sort_by(|a, b| match (a.classify(&self.gc), b.classify(&self.gc)) {
+                            (ValueKind::Int(x), ValueKind::Int(y)) => x.cmp(&y),
+                            (ValueKind::Float(x), ValueKind::Float(y)) => {
+                                x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal)
                             }
-                            (Value::Obj(rx), Value::Obj(ry)) => {
-                                let sx = self.get_string(&Value::obj(*rx)).unwrap_or_default();
-                                let sy = self.get_string(&Value::obj(*ry)).unwrap_or_default();
+                            (ValueKind::Obj(rx), ValueKind::Obj(ry)) => {
+                                let sx = self.get_string(&Value::obj(rx)).unwrap_or_default();
+                                let sy = self.get_string(&Value::obj(ry)).unwrap_or_default();
                                 sx.cmp(&sy)
                             }
                             _ => std::cmp::Ordering::Equal,
@@ -959,8 +966,8 @@ impl VM {
                 Err(VMError::new("sort() requires an array"))
             }
             "reverse" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             let mut rev = items.clone();
                             rev.reverse();
@@ -971,9 +978,9 @@ impl VM {
                 }
                 Err(VMError::new("reverse() requires an array"))
             }
-            "contains" => match (args.first(), args.get(1)) {
-                (Some(Value::Obj(r)), Some(val)) => {
-                    if let Some(obj) = self.gc.get(*r) {
+            "contains" => match (args.first().and_then(|v| v.as_obj()), args.get(1)) {
+                (Some(r), Some(val)) => {
+                    if let Some(obj) = self.gc.get(r) {
                         match &obj.kind {
                             ObjKind::String(s) => {
                                 let sub = val.display(&self.gc);
@@ -993,8 +1000,8 @@ impl VM {
                 _ => Err(VMError::new("contains() requires (collection, value)")),
             },
             "keys" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             // Collect keys as owned Strings first to release gc borrow
                             let key_strings: Vec<String> = map.keys().cloned().collect();
@@ -1009,8 +1016,8 @@ impl VM {
                 Err(VMError::new("keys() requires an object"))
             }
             "values" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             let vals: Vec<Value> = map.values().cloned().collect();
                             let nr = self.gc.alloc(ObjKind::Array(vals));
@@ -1021,8 +1028,8 @@ impl VM {
                 Err(VMError::new("values() requires an object"))
             }
             "enumerate" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let items_clone: Option<Vec<Value>> = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let items_clone: Option<Vec<Value>> = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             Some(items.clone())
                         } else {
@@ -1047,9 +1054,12 @@ impl VM {
                 Err(VMError::new("enumerate() requires an array"))
             }
             "split" => {
-                if let (Some(Value::Obj(r1)), Some(Value::Obj(r2))) = (args.first(), args.get(1)) {
-                    let s = self.get_string(&Value::obj(*r1)).unwrap_or_default();
-                    let delim = self.get_string(&Value::obj(*r2)).unwrap_or_default();
+                if let (Some(r1), Some(r2)) = (
+                    args.first().and_then(|v| v.as_obj()),
+                    args.get(1).and_then(|v| v.as_obj()),
+                ) {
+                    let s = self.get_string(&Value::obj(r1)).unwrap_or_default();
+                    let delim = self.get_string(&Value::obj(r2)).unwrap_or_default();
                     // Parity with interpreter: empty delimiter splits into individual chars
                     let parts: Vec<Value> = if delim.is_empty() {
                         s.chars()
@@ -1064,8 +1074,8 @@ impl VM {
                 Err(VMError::new("split() requires (string, delimiter)"))
             }
             "join" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             let sep = args.get(1).map(|v| v.display(&self.gc)).unwrap_or_default();
                             let parts: Vec<String> =
@@ -1101,14 +1111,14 @@ impl VM {
                 }
                 Err(VMError::new("ends_with() requires (string, suffix)"))
             }
-            "wait" => match args.first() {
-                Some(Value::Int(secs)) => {
+            "wait" => match args.first().map(|v| v.classify(&self.gc)) {
+                Some(ValueKind::Int(secs)) => {
                     self.sleep_with_timeout_checks(std::time::Duration::from_secs(
-                        (*secs).max(0) as u64
+                        secs.max(0) as u64
                     ))?;
                     Ok(Value::null())
                 }
-                Some(Value::Float(secs)) => {
+                Some(ValueKind::Float(secs)) => {
                     self.sleep_with_timeout_checks(std::time::Duration::from_secs_f64(
                         secs.max(0.0),
                     ))?;
@@ -1129,10 +1139,10 @@ impl VM {
                 }
             }
             "is_some" => {
-                match args.first() {
+                match args.first().map(|v| v.classify(&self.gc)) {
                     // Native Option encoding via ADT object
-                    Some(Value::Obj(r)) => {
-                        if let Some(obj) = self.gc.get(*r) {
+                    Some(ValueKind::Obj(r)) => {
+                        if let Some(obj) = self.gc.get(r) {
                             if let ObjKind::Object(map) = &obj.kind {
                                 // Check __type__ == "Option" and __variant__ == "Some"
                                 let is_option = map
@@ -1153,15 +1163,15 @@ impl VM {
                         }
                         Ok(Value::bool_val(true)) // non-null Obj is Some
                     }
-                    Some(Value::Null) => Ok(Value::bool_val(false)),
+                    Some(ValueKind::Null) => Ok(Value::bool_val(false)),
                     Some(_) => Ok(Value::bool_val(true)),
                     None => Err(VMError::new("is_some() requires an argument")),
                 }
             }
             "is_none" => {
-                match args.first() {
-                    Some(Value::Obj(r)) => {
-                        if let Some(obj) = self.gc.get(*r) {
+                match args.first().map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Obj(r)) => {
+                        if let Some(obj) = self.gc.get(r) {
                             if let ObjKind::Object(map) = &obj.kind {
                                 let is_option = map
                                     .get("__type__")
@@ -1180,7 +1190,7 @@ impl VM {
                         }
                         Ok(Value::bool_val(false)) // non-null Obj is Some
                     }
-                    Some(Value::Null) => Ok(Value::bool_val(true)),
+                    Some(ValueKind::Null) => Ok(Value::bool_val(true)),
                     Some(_) => Ok(Value::bool_val(false)),
                     None => Err(VMError::new("is_none() requires an argument")),
                 }
@@ -1239,16 +1249,16 @@ impl VM {
             n if n.starts_with("crypto.") => {
                 let str_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(obj) = self.gc.get(*r) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(obj) = self.gc.get(r) {
                                 if let ObjKind::String(s) = &obj.kind {
                                     return crate::interpreter::Value::String(s.clone());
                                 }
                             }
                             crate::interpreter::Value::Null
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1262,16 +1272,16 @@ impl VM {
             n if n.starts_with("db.") => {
                 let str_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(obj) = self.gc.get(*r) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(obj) = self.gc.get(r) {
                                 if let ObjKind::String(s) = &obj.kind {
                                     return crate::interpreter::Value::String(s.clone());
                                 }
                             }
                             crate::interpreter::Value::Null
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1340,9 +1350,9 @@ impl VM {
                     Err(VMError::new(&format!("invalid ADT constructor: {}", n)))
                 }
             }
-            "fetch" => match args.first() {
-                Some(Value::Obj(r)) => {
-                    let url = self.get_string(&Value::obj(*r)).unwrap_or_default();
+            "fetch" => match args.first().map(|v| v.classify(&self.gc)) {
+                Some(ValueKind::Obj(r)) => {
+                    let url = self.get_string(&Value::obj(r)).unwrap_or_default();
                     let method = "GET".to_string();
                     match crate::runtime::client::fetch_blocking(
                         &url, &method, None, None, None, None, None,
@@ -1354,8 +1364,8 @@ impl VM {
                 _ => Err(VMError::new("fetch() requires a URL string")),
             },
             "exit" => {
-                let code = match args.first() {
-                    Some(Value::Int(n)) => *n as i32,
+                let code = match args.first().map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => n as i32,
                     _ => 0,
                 };
                 std::process::exit(code);
@@ -1364,15 +1374,15 @@ impl VM {
                 crate::permissions::check_run_permission().map_err(|e| VMError::new(&e))?;
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1383,9 +1393,9 @@ impl VM {
             n if n.starts_with("os.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1401,17 +1411,17 @@ impl VM {
             n if n.starts_with("path.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
-                        Value::Float(n) => crate::interpreter::Value::Float(*n),
-                        Value::Bool(b) => crate::interpreter::Value::Bool(*b),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
+                        ValueKind::Float(n) => crate::interpreter::Value::Float(n),
+                        ValueKind::Bool(b) => crate::interpreter::Value::Bool(b),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1422,9 +1432,9 @@ impl VM {
             n if n.starts_with("env.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1440,17 +1450,17 @@ impl VM {
             n if n.starts_with("json.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
-                        Value::Float(n) => crate::interpreter::Value::Float(*n),
-                        Value::Bool(b) => crate::interpreter::Value::Bool(*b),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
+                        ValueKind::Float(n) => crate::interpreter::Value::Float(n),
+                        ValueKind::Bool(b) => crate::interpreter::Value::Bool(b),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1461,9 +1471,9 @@ impl VM {
             n if n.starts_with("regex.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
@@ -1479,15 +1489,15 @@ impl VM {
             n if n.starts_with("log.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1497,11 +1507,11 @@ impl VM {
             n if n.starts_with("http.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
-                            } else if let Some(obj) = self.gc.get(*r) {
+                            } else if let Some(obj) = self.gc.get(r) {
                                 if let ObjKind::Object(map) = &obj.kind {
                                     let mut im = indexmap::IndexMap::new();
                                     for (k, val) in map {
@@ -1515,9 +1525,9 @@ impl VM {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
-                        Value::Float(n) => crate::interpreter::Value::Float(*n),
-                        Value::Bool(b) => crate::interpreter::Value::Bool(*b),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
+                        ValueKind::Float(n) => crate::interpreter::Value::Float(n),
+                        ValueKind::Bool(b) => crate::interpreter::Value::Bool(b),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1528,15 +1538,15 @@ impl VM {
             n if n.starts_with("term.") => {
                 let interp_args: Vec<crate::interpreter::Value> = args
                     .iter()
-                    .map(|v| match v {
-                        Value::Obj(r) => {
-                            if let Some(s) = self.get_string(&Value::obj(*r)) {
+                    .map(|v| match v.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(s) = self.get_string(&Value::obj(r)) {
                                 crate::interpreter::Value::String(s)
                             } else {
                                 crate::interpreter::Value::Null
                             }
                         }
-                        Value::Int(n) => crate::interpreter::Value::Int(*n),
+                        ValueKind::Int(n) => crate::interpreter::Value::Int(n),
                         _ => crate::interpreter::Value::Null,
                     })
                     .collect();
@@ -1755,9 +1765,11 @@ impl VM {
                 Ok(Value::obj(r))
             }
             "has_key" => {
-                if let (Some(Value::Obj(r)), Some(key_val)) = (args.first(), args.get(1)) {
+                if let (Some(r), Some(key_val)) =
+                    (args.first().and_then(|v| v.as_obj()), args.get(1))
+                {
                     let key = self.get_string(key_val).unwrap_or_default();
-                    if let Some(obj) = self.gc.get(*r) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             return Ok(Value::bool_val(map.contains_key(&key)));
                         }
@@ -1766,10 +1778,12 @@ impl VM {
                 Ok(Value::bool_val(false))
             }
             "get" => {
-                if let (Some(Value::Obj(r)), Some(key_val)) = (args.first(), args.get(1)) {
+                if let (Some(r), Some(key_val)) =
+                    (args.first().and_then(|v| v.as_obj()), args.get(1))
+                {
                     let key = self.get_string(key_val).unwrap_or_default();
                     let default = args.get(2).cloned().unwrap_or(Value::null());
-                    if let Some(obj) = self.gc.get(*r) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             if key.contains('.') {
                                 let parts: Vec<&str> = key.split('.').collect();
@@ -1779,8 +1793,8 @@ impl VM {
                                         if i == parts.len() - 1 {
                                             return Ok(val.clone());
                                         }
-                                        if let Value::Obj(inner_r) = val {
-                                            if let Some(inner_obj) = self.gc.get(*inner_r) {
+                                        if let Some(inner_r) = val.as_obj() {
+                                            if let Some(inner_obj) = self.gc.get(inner_r) {
                                                 if let ObjKind::Object(inner_map) = &inner_obj.kind
                                                 {
                                                     current_map = inner_map.clone();
@@ -1803,10 +1817,12 @@ impl VM {
                 }
             }
             "pick" => {
-                if let (Some(Value::Obj(r)), Some(Value::Obj(keys_r))) = (args.first(), args.get(1))
-                {
+                if let (Some(r), Some(keys_r)) = (
+                    args.first().and_then(|v| v.as_obj()),
+                    args.get(1).and_then(|v| v.as_obj()),
+                ) {
                     let mut result = IndexMap::new();
-                    let field_names: Vec<String> = if let Some(obj) = self.gc.get(*keys_r) {
+                    let field_names: Vec<String> = if let Some(obj) = self.gc.get(keys_r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             items.iter().filter_map(|v| self.get_string(v)).collect()
                         } else {
@@ -1815,7 +1831,7 @@ impl VM {
                     } else {
                         vec![]
                     };
-                    if let Some(obj) = self.gc.get(*r) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             for name in &field_names {
                                 if let Some(val) = map.get(name) {
@@ -1831,9 +1847,11 @@ impl VM {
                 }
             }
             "omit" => {
-                if let (Some(Value::Obj(r)), Some(Value::Obj(keys_r))) = (args.first(), args.get(1))
-                {
-                    let omit_names: Vec<String> = if let Some(obj) = self.gc.get(*keys_r) {
+                if let (Some(r), Some(keys_r)) = (
+                    args.first().and_then(|v| v.as_obj()),
+                    args.get(1).and_then(|v| v.as_obj()),
+                ) {
+                    let omit_names: Vec<String> = if let Some(obj) = self.gc.get(keys_r) {
                         if let ObjKind::Array(items) = &obj.kind {
                             items.iter().filter_map(|v| self.get_string(v)).collect()
                         } else {
@@ -1843,7 +1861,7 @@ impl VM {
                         vec![]
                     };
                     let mut result = IndexMap::new();
-                    if let Some(obj) = self.gc.get(*r) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             for (k, v) in map {
                                 if !omit_names.contains(k) {
@@ -1861,8 +1879,8 @@ impl VM {
             "merge" => {
                 let mut result = IndexMap::new();
                 for arg in &args {
-                    if let Value::Obj(r) = arg {
-                        if let Some(obj) = self.gc.get(*r) {
+                    if let Some(r) = arg.as_obj() {
+                        if let Some(obj) = self.gc.get(r) {
                             if let ObjKind::Object(map) = &obj.kind {
                                 for (k, v) in map {
                                     result.insert(k.clone(), v.clone());
@@ -1875,8 +1893,8 @@ impl VM {
                 Ok(Value::obj(r))
             }
             "entries" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    let kv_pairs: Vec<(String, Value)> = if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    let kv_pairs: Vec<(String, Value)> = if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Object(map) = &obj.kind {
                             map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
                         } else {
@@ -1898,14 +1916,14 @@ impl VM {
                 Err(VMError::new("entries() requires an object"))
             }
             "from_entries" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(pairs) = &obj.kind {
                             let mut result = IndexMap::new();
                             let pairs_clone = pairs.clone();
                             for pair in &pairs_clone {
-                                if let Value::Obj(pr) = pair {
-                                    if let Some(pobj) = self.gc.get(*pr) {
+                                if let Some(pr) = pair.as_obj() {
+                                    if let Some(pobj) = self.gc.get(pr) {
                                         if let ObjKind::Array(kv) = &pobj.kind {
                                             if let (Some(k), Some(v)) = (kv.first(), kv.get(1)) {
                                                 if let Some(key) = self.get_string(k) {
@@ -1928,8 +1946,8 @@ impl VM {
                 if args.len() < 2 {
                     return Err(VMError::new("find() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -1955,8 +1973,8 @@ impl VM {
                 if args.len() < 2 {
                     return Err(VMError::new("flat_map() requires (array, function)"));
                 }
-                let items = if let Value::Obj(r) = &args[0] {
-                    if let Some(obj) = self.gc.get(*r) {
+                let items = if let Some(r) = args[0].as_obj() {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::Array(a) = &obj.kind {
                             a.clone()
                         } else {
@@ -1972,8 +1990,8 @@ impl VM {
                 let mut out = Vec::new();
                 for item in items {
                     let result = self.call_value(func.clone(), vec![item])?;
-                    match result {
-                        Value::Obj(r) => {
+                    match result.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
                             if let Some(obj) = self.gc.get(r) {
                                 if let ObjKind::Array(sub) = &obj.kind {
                                     out.extend(sub.clone());
@@ -1982,7 +2000,7 @@ impl VM {
                             }
                             out.push(Value::obj(r));
                         }
-                        other => out.push(other),
+                        _ => out.push(result),
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(out));
@@ -2039,9 +2057,9 @@ impl VM {
                 )?;
                 let mut result = Vec::new();
                 for item in items {
-                    match &item {
-                        Value::Obj(r) => {
-                            if let Some(obj) = self.gc.get(*r) {
+                    match item.classify(&self.gc) {
+                        ValueKind::Obj(r) => {
+                            if let Some(obj) = self.gc.get(r) {
                                 if let ObjKind::Array(inner) = &obj.kind {
                                     result.extend(inner.clone());
                                     continue;
@@ -2049,7 +2067,7 @@ impl VM {
                             }
                             result.push(item);
                         }
-                        other => result.push(other.clone()),
+                        _ => result.push(item),
                     }
                 }
                 let r = self.gc.alloc(ObjKind::Array(result));
@@ -2060,8 +2078,8 @@ impl VM {
                     return Err(VMError::new("chunk() requires (array, size)"));
                 }
                 let items = self.array_items(&args[0], "chunk() first arg must be array")?;
-                let size = match args[1] {
-                    Value::Int(n) if n > 0 => n as usize,
+                let size = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) if n > 0 => n as usize,
                     _ => return Err(VMError::new("chunk() size must be positive")),
                 };
                 let chunks: Vec<Value> = items
@@ -2082,22 +2100,22 @@ impl VM {
                 if let Some(s) = self.get_string(first) {
                     let chars: Vec<char> = s.chars().collect();
                     let len = chars.len() as i64;
-                    let start = match args.get(1) {
-                        Some(Value::Int(n)) => {
-                            if *n < 0 {
-                                (len + *n).max(0) as usize
+                    let start = match args.get(1).map(|v| v.classify(&self.gc)) {
+                        Some(ValueKind::Int(n)) => {
+                            if n < 0 {
+                                (len + n).max(0) as usize
                             } else {
-                                *n as usize
+                                n as usize
                             }
                         }
                         _ => 0,
                     };
-                    let end = match args.get(2) {
-                        Some(Value::Int(n)) => {
-                            if *n < 0 {
-                                (len + *n).max(0) as usize
+                    let end = match args.get(2).map(|v| v.classify(&self.gc)) {
+                        Some(ValueKind::Int(n)) => {
+                            if n < 0 {
+                                (len + n).max(0) as usize
                             } else {
-                                (*n as usize).min(chars.len())
+                                (n as usize).min(chars.len())
                             }
                         }
                         _ => chars.len(),
@@ -2110,22 +2128,22 @@ impl VM {
                 // Array
                 let items = self.array_items(first, "slice() requires an array or string")?;
                 let len = items.len() as i64;
-                let start = match args.get(1) {
-                    Some(Value::Int(n)) => {
-                        if *n < 0 {
-                            (len + *n).max(0) as usize
+                let start = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => {
+                        if n < 0 {
+                            (len + n).max(0) as usize
                         } else {
-                            *n as usize
+                            n as usize
                         }
                     }
                     _ => 0,
                 };
-                let end = match args.get(2) {
-                    Some(Value::Int(n)) => {
-                        if *n < 0 {
-                            (len + *n).max(0) as usize
+                let end = match args.get(2).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => {
+                        if n < 0 {
+                            (len + n).max(0) as usize
                         } else {
-                            (*n as usize).min(items.len())
+                            (n as usize).min(items.len())
                         }
                     }
                     _ => items.len(),
@@ -2145,7 +2163,7 @@ impl VM {
                 )?;
                 let filtered: Vec<Value> = items
                     .into_iter()
-                    .filter(|v| !matches!(v, Value::Null | Value::Bool(false)))
+                    .filter(|v| !v.is_null() && v.as_bool() != Some(false))
                     .collect();
                 let r = self.gc.alloc(ObjKind::Array(filtered));
                 Ok(Value::obj(r))
@@ -2206,21 +2224,23 @@ impl VM {
                     let key = self.call_value(key_fn.clone(), vec![item.clone()])?;
                     pairs.push((key, item));
                 }
-                pairs.sort_by(|(ka, _), (kb, _)| match (ka, kb) {
-                    (Value::Int(a), Value::Int(b)) => a.cmp(b),
-                    (Value::Float(a), Value::Float(b)) => {
-                        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-                    }
-                    (Value::Int(a), Value::Float(b)) => (*a as f64)
-                        .partial_cmp(b)
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    (Value::Float(a), Value::Int(b)) => a
-                        .partial_cmp(&(*b as f64))
-                        .unwrap_or(std::cmp::Ordering::Equal),
-                    _ => {
-                        let sa = ka.display(&self.gc);
-                        let sb = kb.display(&self.gc);
-                        sa.cmp(&sb)
+                pairs.sort_by(|(ka, _), (kb, _)| {
+                    match (ka.classify(&self.gc), kb.classify(&self.gc)) {
+                        (ValueKind::Int(a), ValueKind::Int(b)) => a.cmp(&b),
+                        (ValueKind::Float(a), ValueKind::Float(b)) => {
+                            a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
+                        }
+                        (ValueKind::Int(a), ValueKind::Float(b)) => (a as f64)
+                            .partial_cmp(&b)
+                            .unwrap_or(std::cmp::Ordering::Equal),
+                        (ValueKind::Float(a), ValueKind::Int(b)) => a
+                            .partial_cmp(&(b as f64))
+                            .unwrap_or(std::cmp::Ordering::Equal),
+                        _ => {
+                            let sa = ka.display(&self.gc);
+                            let sb = kb.display(&self.gc);
+                            sa.cmp(&sb)
+                        }
                     }
                 });
                 let sorted: Vec<Value> = pairs.into_iter().map(|(_, v)| v).collect();
@@ -2243,8 +2263,8 @@ impl VM {
                     return Err(VMError::new("take_n() requires (array, count)"));
                 }
                 let items = self.array_items(&args[0], "take_n() first arg must be array")?;
-                let n = match args[1] {
-                    Value::Int(n) => (n.max(0) as usize).min(items.len()),
+                let n = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) => (n.max(0) as usize).min(items.len()),
                     _ => return Err(VMError::new("take_n() second arg must be int")),
                 };
                 let r = self.gc.alloc(ObjKind::Array(items[..n].to_vec()));
@@ -2255,8 +2275,8 @@ impl VM {
                     return Err(VMError::new("skip() requires (array, count)"));
                 }
                 let items = self.array_items(&args[0], "skip() first arg must be array")?;
-                let n = match args[1] {
-                    Value::Int(n) => (n.max(0) as usize).min(items.len()),
+                let n = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) => (n.max(0) as usize).min(items.len()),
                     _ => return Err(VMError::new("skip() second arg must be int")),
                 };
                 let r = self.gc.alloc(ObjKind::Array(items[n..].to_vec()));
@@ -2274,8 +2294,8 @@ impl VM {
                     let count = counts
                         .get(&key)
                         .and_then(|v| {
-                            if let Value::Int(n) = v {
-                                Some(*n)
+                            if let Some(n) = v.as_int(&self.gc) {
+                                Some(n)
                             } else {
                                 None
                             }
@@ -2290,13 +2310,13 @@ impl VM {
             // ===== String builtins =====
             "substring" => {
                 let s = self.get_string_arg(&args, 0)?;
-                let start = match args.get(1) {
-                    Some(Value::Int(n)) => *n as usize,
+                let start = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => n as usize,
                     _ => return Err(VMError::new("substring() requires (string, start, end?)")),
                 };
                 let chars: Vec<char> = s.chars().collect();
-                let end = match args.get(2) {
-                    Some(Value::Int(n)) => (*n as usize).min(chars.len()),
+                let end = match args.get(2).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => (n as usize).min(chars.len()),
                     _ => chars.len(),
                 };
                 if start > chars.len() {
@@ -2379,8 +2399,8 @@ impl VM {
                     return Err(VMError::new("pad_start() requires (string, length)"));
                 }
                 let s = self.get_string_arg(&args, 0)?;
-                let target = match args[1] {
-                    Value::Int(n) => n as usize,
+                let target = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) => n as usize,
                     _ => return Err(VMError::new("pad_start() second arg must be int")),
                 };
                 let pad_char = match args.get(2) {
@@ -2405,8 +2425,8 @@ impl VM {
                     return Err(VMError::new("pad_end() requires (string, length)"));
                 }
                 let s = self.get_string_arg(&args, 0)?;
-                let target = match args[1] {
-                    Value::Int(n) => n as usize,
+                let target = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) => n as usize,
                     _ => return Err(VMError::new("pad_end() second arg must be int")),
                 };
                 let pad_char = match args.get(2) {
@@ -2431,9 +2451,9 @@ impl VM {
                     return Err(VMError::new("repeat_str() requires (string, count)"));
                 }
                 let s = self.get_string_arg(&args, 0)?;
-                let n = match args[1] {
-                    Value::Int(n) if n >= 0 => n as usize,
-                    Value::Int(_) => {
+                let n = match args[1].classify(&self.gc) {
+                    ValueKind::Int(n) if n >= 0 => n as usize,
+                    ValueKind::Int(_) => {
                         return Err(VMError::new("repeat_str() count must be non-negative"))
                     }
                     _ => return Err(VMError::new("repeat_str() second arg must be int")),
@@ -2519,8 +2539,8 @@ impl VM {
                         .ok_or_else(|| VMError::new("sample() requires an array"))?,
                     "sample() requires an array",
                 )?;
-                let n = match args.get(1) {
-                    Some(Value::Int(n)) => *n as usize,
+                let n = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => n as usize,
                     _ => 1,
                 };
                 if items.is_empty() {
@@ -2576,8 +2596,8 @@ impl VM {
                 Ok(self.alloc_string(buffer.trim_end()))
             }
             "unwrap_err" => {
-                if let Some(Value::Obj(r)) = args.first() {
-                    if let Some(obj) = self.gc.get(*r) {
+                if let Some(r) = args.first().and_then(|v| v.as_obj()) {
+                    if let Some(obj) = self.gc.get(r) {
                         if let ObjKind::ResultErr(v) = &obj.kind {
                             return Ok(self.alloc_string(&v.display(&self.gc)));
                         }
@@ -2700,8 +2720,8 @@ impl VM {
                 Err(VMError::new(&format!("BRUH: {}", msg)))
             }
             "bet" => {
-                let condition = match args.first() {
-                    Some(Value::Bool(b)) => *b,
+                let condition = match args.first().map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Bool(b)) => b,
                     Some(_) => true,
                     None => return Err(VMError::new("bet() needs a condition, no cap")),
                 };
@@ -2728,8 +2748,8 @@ impl VM {
                 }
             }
             "ick" => {
-                let condition = match args.first() {
-                    Some(Value::Bool(b)) => *b,
+                let condition = match args.first().map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Bool(b)) => b,
                     Some(_) => true,
                     None => return Err(VMError::new("ick() needs a condition to reject")),
                 };
@@ -2793,8 +2813,8 @@ impl VM {
                     return Err(VMError::new("slay() needs a function to benchmark"));
                 }
                 let func = args[0].clone();
-                let n = match args.get(1) {
-                    Some(Value::Int(n)) => *n as usize,
+                let n = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(n)) => n as usize,
                     _ => 100,
                 };
                 let mut times: Vec<f64> = Vec::with_capacity(n);
@@ -2830,9 +2850,9 @@ impl VM {
 
             // ----- Channel builtins -----
             "channel" => {
-                let (sender, receiver) = match args.first() {
-                    Some(Value::Int(cap)) => {
-                        let cap = (*cap).max(0) as usize;
+                let (sender, receiver) = match args.first().map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(cap)) => {
+                        let cap = cap.max(0) as usize;
                         let (tx, rx) = std::sync::mpsc::sync_channel(cap);
                         (VmChannelSender::Bounded(tx), rx)
                     }
@@ -2931,8 +2951,8 @@ impl VM {
                     return Err(VMError::new("select() requires an array of channels"));
                 }
                 // Extract channels from the array argument
-                let channels: Vec<Arc<VmChannelInner>> = match &args[0] {
-                    Value::Obj(r) => match self.gc.get(*r) {
+                let channels: Vec<Arc<VmChannelInner>> = match args[0].classify(&self.gc) {
+                    ValueKind::Obj(r) => match self.gc.get(r) {
                         Some(obj) => match &obj.kind {
                             ObjKind::Array(items) => {
                                 let mut chs = Vec::with_capacity(items.len());
@@ -2952,9 +2972,9 @@ impl VM {
                 if channels.is_empty() {
                     return Ok(Value::null());
                 }
-                let timeout_ms: Option<u128> = match args.get(1) {
-                    Some(Value::Int(ms)) => Some((*ms).max(0) as u128),
-                    Some(Value::Float(ms)) => Some(ms.max(0.0) as u128),
+                let timeout_ms: Option<u128> = match args.get(1).map(|v| v.classify(&self.gc)) {
+                    Some(ValueKind::Int(ms)) => Some((ms).max(0) as u128),
+                    Some(ValueKind::Float(ms)) => Some(ms.max(0.0) as u128),
                     _ => None,
                 };
                 let start = std::time::Instant::now();
@@ -3039,8 +3059,8 @@ impl VM {
                     ));
                 }
                 // Extract array items, releasing the GC borrow
-                let items: Vec<Value> = match &args[0] {
-                    Value::Obj(r) => match self.gc.get(*r) {
+                let items: Vec<Value> = match args[0].classify(&self.gc) {
+                    ValueKind::Obj(r) => match self.gc.get(r) {
                         Some(obj) => match &obj.kind {
                             ObjKind::Array(arr) => arr.clone(),
                             _ => {
@@ -3073,9 +3093,9 @@ impl VM {
                         let shared = guard.as_ref().cloned().unwrap_or(SharedValue::Null);
                         let val = shared_to_value(&mut self.gc, &shared);
                         // Fail-fast: propagate ResultErr immediately
-                        match &val {
-                            Value::Obj(r) => {
-                                if let Some(obj) = self.gc.get(*r) {
+                        match val.classify(&self.gc) {
+                            ValueKind::Obj(r) => {
+                                if let Some(obj) = self.gc.get(r) {
                                     if let ObjKind::ResultErr(e) = &obj.kind {
                                         let msg = e.display(&self.gc);
                                         return Err(VMError::new(&format!("task error: {}", msg)));
@@ -3104,9 +3124,9 @@ impl VM {
                         "await_timeout() requires (handle, timeout_ms)",
                     ));
                 }
-                let timeout_ms = match &args[1] {
-                    Value::Int(ms) => (*ms).max(0) as u64,
-                    Value::Float(ms) => ms.max(0.0) as u64,
+                let timeout_ms = match args[1].classify(&self.gc) {
+                    ValueKind::Int(ms) => (ms).max(0) as u64,
+                    ValueKind::Float(ms) => ms.max(0.0) as u64,
                     _ => {
                         return Err(VMError::new(
                             "await_timeout() second argument must be a number (ms)",
@@ -3141,9 +3161,9 @@ impl VM {
                         let shared = guard.as_ref().cloned().unwrap_or(SharedValue::Null);
                         let val = shared_to_value(&mut self.gc, &shared);
                         // Unwrap ResultOk, propagate ResultErr
-                        match &val {
-                            Value::Obj(r) => {
-                                if let Some(obj) = self.gc.get(*r) {
+                        match val.classify(&self.gc) {
+                            ValueKind::Obj(r) => {
+                                if let Some(obj) = self.gc.get(r) {
                                     if let ObjKind::ResultOk(v) = &obj.kind {
                                         return Ok(*v);
                                     }
@@ -3175,8 +3195,8 @@ impl VM {
         &self,
         val: &Value,
     ) -> Option<Arc<(std::sync::Mutex<Option<SharedValue>>, std::sync::Condvar)>> {
-        match val {
-            Value::Obj(r) => self.gc.get(*r).and_then(|obj| {
+        match val.classify(&self.gc) {
+            ValueKind::Obj(r) => self.gc.get(r).and_then(|obj| {
                 if let ObjKind::TaskHandle(slot) = &obj.kind {
                     Some(slot.clone())
                 } else {
@@ -3196,8 +3216,8 @@ impl VM {
     }
 
     fn extract_channel(&self, val: &Value) -> Result<Arc<VmChannelInner>, VMError> {
-        match val {
-            Value::Obj(r) => match self.gc.get(*r) {
+        match val.classify(&self.gc) {
+            ValueKind::Obj(r) => match self.gc.get(r) {
                 Some(obj) => match &obj.kind {
                     ObjKind::Channel(ch) => Ok(ch.clone()),
                     _ => Err(VMError::new("expected channel")),
@@ -3209,22 +3229,22 @@ impl VM {
     }
 
     fn parse_object_fields(&self, value: &Value) -> Result<IndexMap<String, Value>, VMError> {
-        match value {
-            Value::Obj(r) => match self.gc.get(*r) {
+        match value.classify(&self.gc) {
+            ValueKind::Obj(r) => match self.gc.get(r) {
                 Some(obj) => match &obj.kind {
                     ObjKind::Object(map) => Ok(map.clone()),
                     _ => Err(VMError::new("expected object value")),
                 },
                 None => Err(VMError::new("dangling object reference")),
             },
-            Value::Null => Ok(IndexMap::new()),
+            ValueKind::Null => Ok(IndexMap::new()),
             _ => Err(VMError::new("expected object value")),
         }
     }
 
     fn get_object_fields(&self, value: &Value) -> Option<IndexMap<String, Value>> {
-        match value {
-            Value::Obj(r) => self.gc.get(*r).and_then(|obj| match &obj.kind {
+        match value.classify(&self.gc) {
+            ValueKind::Obj(r) => self.gc.get(r).and_then(|obj| match &obj.kind {
                 ObjKind::Object(map) => Some(map.clone()),
                 _ => None,
             }),
@@ -3233,8 +3253,8 @@ impl VM {
     }
 
     fn array_items(&self, value: &Value, message: &str) -> Result<Vec<Value>, VMError> {
-        match value {
-            Value::Obj(r) => match self.gc.get(*r) {
+        match value.classify(&self.gc) {
+            ValueKind::Obj(r) => match self.gc.get(r) {
                 Some(obj) => match &obj.kind {
                     ObjKind::Array(items) => Ok(items.clone()),
                     _ => Err(VMError::new(message)),
@@ -3264,24 +3284,24 @@ impl VM {
     }
 
     fn query_value_cmp(&self, left: &Value, right: &Value) -> std::cmp::Ordering {
-        match (left, right) {
-            (Value::Int(a), Value::Int(b)) => a.cmp(b),
-            (Value::Float(a), Value::Float(b)) => {
-                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+        match (left.classify(&self.gc), right.classify(&self.gc)) {
+            (ValueKind::Int(a), ValueKind::Int(b)) => a.cmp(&b),
+            (ValueKind::Float(a), ValueKind::Float(b)) => {
+                a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
             }
-            (Value::Int(a), Value::Float(b)) => (*a as f64)
-                .partial_cmp(b)
+            (ValueKind::Int(a), ValueKind::Float(b)) => (a as f64)
+                .partial_cmp(&b)
                 .unwrap_or(std::cmp::Ordering::Equal),
-            (Value::Float(a), Value::Int(b)) => a
-                .partial_cmp(&(*b as f64))
+            (ValueKind::Float(a), ValueKind::Int(b)) => a
+                .partial_cmp(&(b as f64))
                 .unwrap_or(std::cmp::Ordering::Equal),
             _ => left.display(&self.gc).cmp(&right.display(&self.gc)),
         }
     }
 
     fn parse_embedded_fields(&self, value: &Value) -> Result<Vec<(String, String)>, VMError> {
-        match value {
-            Value::Obj(r) => match self.gc.get(*r) {
+        match value.classify(&self.gc) {
+            ValueKind::Obj(r) => match self.gc.get(r) {
                 Some(obj) => match &obj.kind {
                     ObjKind::Array(items) => {
                         let mut embeds = Vec::new();
@@ -3307,7 +3327,7 @@ impl VM {
                 },
                 None => Err(VMError::new("dangling embedded field metadata")),
             },
-            Value::Null => Ok(Vec::new()),
+            ValueKind::Null => Ok(Vec::new()),
             _ => Err(VMError::new("expected embedded field metadata array")),
         }
     }
@@ -3316,10 +3336,10 @@ impl VM {
         let Some(fields) = self.get_object_fields(iface) else {
             return Vec::new();
         };
-        let Some(Value::Obj(method_ref)) = fields.get("methods") else {
+        let Some(method_ref) = fields.get("methods").and_then(|v| v.as_obj()) else {
             return Vec::new();
         };
-        let Some(method_obj) = self.gc.get(*method_ref) else {
+        let Some(method_obj) = self.gc.get(method_ref) else {
             return Vec::new();
         };
         let ObjKind::Array(methods) = &method_obj.kind else {
@@ -3363,8 +3383,8 @@ impl VM {
     }
 
     fn is_callable_value(&self, value: &Value) -> bool {
-        match value {
-            Value::Obj(r) => self.gc.get(*r).is_some_and(|obj| {
+        match value.classify(&self.gc) {
+            ValueKind::Obj(r) => self.gc.get(r).is_some_and(|obj| {
                 matches!(
                     obj.kind,
                     ObjKind::Function(_) | ObjKind::Closure(_) | ObjKind::NativeFunction(_)

--- a/src/vm/gc.rs
+++ b/src/vm/gc.rs
@@ -128,16 +128,7 @@ impl Gc {
     /// Collect all GcRefs from a set of values.
     #[allow(dead_code)]
     pub fn roots_from_values(values: &[Value]) -> Vec<GcRef> {
-        values
-            .iter()
-            .filter_map(|v| {
-                if let Value::Obj(r) = v {
-                    Some(*r)
-                } else {
-                    None
-                }
-            })
-            .collect()
+        values.iter().filter_map(|v| v.as_obj()).collect()
     }
 
     /// Number of entries in the intern table (for testing).

--- a/src/vm/jit/runtime.rs
+++ b/src/vm/jit/runtime.rs
@@ -48,7 +48,15 @@ pub fn decode_value(encoded: u64) -> Value {
             } else {
                 payload as i64
             };
-            Value::small_int(n)
+            // JIT uses 60-bit payload which can exceed NaN-box 48-bit inline range.
+            // Fall back to float if we can't inline (no gc available for BoxedInt).
+            const INT48_MAX: i64 = (1_i64 << 47) - 1;
+            const INT48_MIN: i64 = -(1_i64 << 47);
+            if n >= INT48_MIN && n <= INT48_MAX {
+                Value::small_int(n)
+            } else {
+                Value::float(n as f64)
+            }
         }
         TAG_FLOAT => {
             let bits = payload;

--- a/src/vm/jit/runtime.rs
+++ b/src/vm/jit/runtime.rs
@@ -48,16 +48,16 @@ pub fn decode_value(encoded: u64) -> Value {
             } else {
                 payload as i64
             };
-            Value::Int(n)
+            Value::small_int(n)
         }
         TAG_FLOAT => {
             let bits = payload;
-            Value::Float(f64::from_bits(bits))
+            Value::float(f64::from_bits(bits))
         }
-        TAG_BOOL => Value::Bool(payload != 0),
-        TAG_NULL => Value::Null,
-        TAG_OBJ => Value::Obj(GcRef(payload as usize)),
-        _ => Value::Null,
+        TAG_BOOL => Value::bool_val(payload != 0),
+        TAG_NULL => Value::null(),
+        TAG_OBJ => Value::obj(GcRef(payload as usize)),
+        _ => Value::null(),
     }
 }
 

--- a/src/vm/jit/runtime.rs
+++ b/src/vm/jit/runtime.rs
@@ -25,16 +25,16 @@ const TAG_OBJ: u64 = 4;
 const TAG_SHIFT: u64 = 60;
 const PAYLOAD_MASK: u64 = (1u64 << 60) - 1;
 
-pub fn encode_value(v: &Value) -> u64 {
-    match v {
-        Value::Int(n) => (TAG_INT << TAG_SHIFT) | (*n as u64 & PAYLOAD_MASK),
-        Value::Float(f) => {
+pub fn encode_value(v: &Value, gc: &crate::vm::gc::Gc) -> u64 {
+    match v.classify(gc) {
+        crate::vm::value::ValueKind::Int(n) => (TAG_INT << TAG_SHIFT) | (n as u64 & PAYLOAD_MASK),
+        crate::vm::value::ValueKind::Float(f) => {
             let bits = f.to_bits();
             (TAG_FLOAT << TAG_SHIFT) | (bits & PAYLOAD_MASK)
         }
-        Value::Bool(b) => (TAG_BOOL << TAG_SHIFT) | (*b as u64),
-        Value::Null => TAG_NULL << TAG_SHIFT,
-        Value::Obj(GcRef(idx)) => (TAG_OBJ << TAG_SHIFT) | (*idx as u64 & PAYLOAD_MASK),
+        crate::vm::value::ValueKind::Bool(b) => (TAG_BOOL << TAG_SHIFT) | (b as u64),
+        crate::vm::value::ValueKind::Null => TAG_NULL << TAG_SHIFT,
+        crate::vm::value::ValueKind::Obj(r) => (TAG_OBJ << TAG_SHIFT) | (r.0 as u64 & PAYLOAD_MASK),
     }
 }
 
@@ -114,7 +114,7 @@ pub extern "C" fn rt_call_native(
         .map(|i| decode_value(unsafe { *args_ptr.add(i) }))
         .collect();
     match vm.call_value(func, args) {
-        Ok(result) => encode_value(&result),
+        Ok(result) => encode_value(&result, &vm.gc),
         Err(_) => encode_null(),
     }
 }

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -309,7 +309,7 @@ impl std::fmt::Display for VMError {
 impl VM {
     pub fn new() -> Self {
         let mut vm = Self {
-            registers: vec![Value::Null; 256],
+            registers: vec![Value::null(); 256],
             frames: Vec::with_capacity(MAX_FRAMES),
             globals: HashMap::new(),
             method_tables: HashMap::new(),
@@ -331,7 +331,7 @@ impl VM {
 
     pub fn with_profiling() -> Self {
         let mut vm = Self {
-            registers: vec![Value::Null; 256],
+            registers: vec![Value::null(); 256],
             frames: Vec::with_capacity(MAX_FRAMES),
             globals: HashMap::new(),
             method_tables: HashMap::new(),
@@ -510,10 +510,10 @@ impl VM {
             let name_ref = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
                 name: name.to_string(),
             }));
-            self.globals.insert(name.to_string(), Value::Obj(name_ref));
+            self.globals.insert(name.to_string(), Value::obj(name_ref));
         }
 
-        self.globals.insert("null".to_string(), Value::Null);
+        self.globals.insert("null".to_string(), Value::null());
 
         // Register stdlib modules
         self.register_stdlib();
@@ -522,8 +522,8 @@ impl VM {
     fn register_stdlib(&mut self) {
         // math module
         let mut math_map = IndexMap::new();
-        math_map.insert("pi".to_string(), Value::Float(std::f64::consts::PI));
-        math_map.insert("e".to_string(), Value::Float(std::f64::consts::E));
+        math_map.insert("pi".to_string(), Value::float(std::f64::consts::PI));
+        math_map.insert("e".to_string(), Value::float(std::f64::consts::E));
         for name in &[
             "sqrt", "pow", "abs", "max", "min", "floor", "ceil", "round", "random", "sin", "cos",
             "tan", "log",
@@ -532,11 +532,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            math_map.insert(name.to_string(), Value::Obj(nr));
+            math_map.insert(name.to_string(), Value::obj(nr));
         }
         let math_ref = self.gc.alloc(ObjKind::Object(math_map));
         self.globals
-            .insert("math".to_string(), Value::Obj(math_ref));
+            .insert("math".to_string(), Value::obj(math_ref));
 
         // fs module
         let mut fs_map = IndexMap::new();
@@ -547,10 +547,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            fs_map.insert(name.to_string(), Value::Obj(nr));
+            fs_map.insert(name.to_string(), Value::obj(nr));
         }
         let fs_ref = self.gc.alloc(ObjKind::Object(fs_map));
-        self.globals.insert("fs".to_string(), Value::Obj(fs_ref));
+        self.globals.insert("fs".to_string(), Value::obj(fs_ref));
 
         // io module
         let mut io_map = IndexMap::new();
@@ -559,10 +559,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            io_map.insert(name.to_string(), Value::Obj(nr));
+            io_map.insert(name.to_string(), Value::obj(nr));
         }
         let io_ref = self.gc.alloc(ObjKind::Object(io_map));
-        self.globals.insert("io".to_string(), Value::Obj(io_ref));
+        self.globals.insert("io".to_string(), Value::obj(io_ref));
 
         // crypto module
         let mut crypto_map = IndexMap::new();
@@ -578,11 +578,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            crypto_map.insert(name.to_string(), Value::Obj(nr));
+            crypto_map.insert(name.to_string(), Value::obj(nr));
         }
         let crypto_ref = self.gc.alloc(ObjKind::Object(crypto_map));
         self.globals
-            .insert("crypto".to_string(), Value::Obj(crypto_ref));
+            .insert("crypto".to_string(), Value::obj(crypto_ref));
 
         // db module
         let mut db_map = IndexMap::new();
@@ -591,10 +591,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            db_map.insert(name.to_string(), Value::Obj(nr));
+            db_map.insert(name.to_string(), Value::obj(nr));
         }
         let db_ref = self.gc.alloc(ObjKind::Object(db_map));
-        self.globals.insert("db".to_string(), Value::Obj(db_ref));
+        self.globals.insert("db".to_string(), Value::obj(db_ref));
 
         // env module
         let mut env_map = IndexMap::new();
@@ -603,10 +603,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            env_map.insert(name.to_string(), Value::Obj(nr));
+            env_map.insert(name.to_string(), Value::obj(nr));
         }
         let env_ref = self.gc.alloc(ObjKind::Object(env_map));
-        self.globals.insert("env".to_string(), Value::Obj(env_ref));
+        self.globals.insert("env".to_string(), Value::obj(env_ref));
 
         // json module
         let mut json_map = IndexMap::new();
@@ -615,11 +615,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            json_map.insert(name.to_string(), Value::Obj(nr));
+            json_map.insert(name.to_string(), Value::obj(nr));
         }
         let json_ref = self.gc.alloc(ObjKind::Object(json_map));
         self.globals
-            .insert("json".to_string(), Value::Obj(json_ref));
+            .insert("json".to_string(), Value::obj(json_ref));
 
         // regex module
         let mut regex_map = IndexMap::new();
@@ -628,11 +628,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            regex_map.insert(name.to_string(), Value::Obj(nr));
+            regex_map.insert(name.to_string(), Value::obj(nr));
         }
         let regex_ref = self.gc.alloc(ObjKind::Object(regex_map));
         self.globals
-            .insert("regex".to_string(), Value::Obj(regex_ref));
+            .insert("regex".to_string(), Value::obj(regex_ref));
 
         // log module
         let mut log_map = IndexMap::new();
@@ -641,10 +641,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            log_map.insert(name.to_string(), Value::Obj(nr));
+            log_map.insert(name.to_string(), Value::obj(nr));
         }
         let log_ref = self.gc.alloc(ObjKind::Object(log_map));
-        self.globals.insert("log".to_string(), Value::Obj(log_ref));
+        self.globals.insert("log".to_string(), Value::obj(log_ref));
 
         // http module
         let mut http_map = IndexMap::new();
@@ -655,11 +655,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            http_map.insert(name.to_string(), Value::Obj(nr));
+            http_map.insert(name.to_string(), Value::obj(nr));
         }
         let http_ref = self.gc.alloc(ObjKind::Object(http_map));
         self.globals
-            .insert("http".to_string(), Value::Obj(http_ref));
+            .insert("http".to_string(), Value::obj(http_ref));
 
         // term module
         let mut term_map = IndexMap::new();
@@ -671,11 +671,11 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            term_map.insert(name.to_string(), Value::Obj(nr));
+            term_map.insert(name.to_string(), Value::obj(nr));
         }
         let term_ref = self.gc.alloc(ObjKind::Object(term_map));
         self.globals
-            .insert("term".to_string(), Value::Obj(term_ref));
+            .insert("term".to_string(), Value::obj(term_ref));
 
         // csv module
         let mut csv_map = IndexMap::new();
@@ -684,10 +684,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            csv_map.insert(name.to_string(), Value::Obj(nr));
+            csv_map.insert(name.to_string(), Value::obj(nr));
         }
         let csv_ref = self.gc.alloc(ObjKind::Object(csv_map));
-        self.globals.insert("csv".to_string(), Value::Obj(csv_ref));
+        self.globals.insert("csv".to_string(), Value::obj(csv_ref));
 
         // time module
         let mut time_map = IndexMap::new();
@@ -722,16 +722,16 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            time_map.insert(name.to_string(), Value::Obj(nr));
+            time_map.insert(name.to_string(), Value::obj(nr));
         }
         // time() as a function calls the "time" builtin (returns datetime object)
         let time_call = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
             name: "time".to_string(),
         }));
-        time_map.insert("__call__".to_string(), Value::Obj(time_call));
+        time_map.insert("__call__".to_string(), Value::obj(time_call));
         let time_ref = self.gc.alloc(ObjKind::Object(time_map));
         self.globals
-            .insert("time".to_string(), Value::Obj(time_ref));
+            .insert("time".to_string(), Value::obj(time_ref));
 
         // pg module
         #[cfg(feature = "postgres")]
@@ -742,10 +742,10 @@ impl VM {
                 let nr = self
                     .gc
                     .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-                pg_map.insert(name.to_string(), Value::Obj(nr));
+                pg_map.insert(name.to_string(), Value::obj(nr));
             }
             let pg_ref = self.gc.alloc(ObjKind::Object(pg_map));
-            self.globals.insert("pg".to_string(), Value::Obj(pg_ref));
+            self.globals.insert("pg".to_string(), Value::obj(pg_ref));
         }
 
         // jwt module
@@ -755,10 +755,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            jwt_map.insert(name.to_string(), Value::Obj(nr));
+            jwt_map.insert(name.to_string(), Value::obj(nr));
         }
         let jwt_ref = self.gc.alloc(ObjKind::Object(jwt_map));
-        self.globals.insert("jwt".to_string(), Value::Obj(jwt_ref));
+        self.globals.insert("jwt".to_string(), Value::obj(jwt_ref));
 
         // mysql module
         #[cfg(feature = "mysql")]
@@ -769,11 +769,11 @@ impl VM {
                 let nr = self
                     .gc
                     .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-                mysql_map.insert(name.to_string(), Value::Obj(nr));
+                mysql_map.insert(name.to_string(), Value::obj(nr));
             }
             let mysql_ref = self.gc.alloc(ObjKind::Object(mysql_map));
             self.globals
-                .insert("mysql".to_string(), Value::Obj(mysql_ref));
+                .insert("mysql".to_string(), Value::obj(mysql_ref));
         }
 
         // os module
@@ -783,10 +783,10 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            os_map.insert(name.to_string(), Value::Obj(nr));
+            os_map.insert(name.to_string(), Value::obj(nr));
         }
         let os_ref = self.gc.alloc(ObjKind::Object(os_map));
-        self.globals.insert("os".to_string(), Value::Obj(os_ref));
+        self.globals.insert("os".to_string(), Value::obj(os_ref));
 
         // path module
         let mut path_map = IndexMap::new();
@@ -803,7 +803,7 @@ impl VM {
             let nr = self
                 .gc
                 .alloc(ObjKind::NativeFunction(NativeFn { name: full }));
-            path_map.insert(name.to_string(), Value::Obj(nr));
+            path_map.insert(name.to_string(), Value::obj(nr));
         }
         path_map.insert(
             "separator".to_string(),
@@ -811,7 +811,7 @@ impl VM {
         );
         let path_ref = self.gc.alloc(ObjKind::Object(path_map));
         self.globals
-            .insert("path".to_string(), Value::Obj(path_ref));
+            .insert("path".to_string(), Value::obj(path_ref));
 
         // Option prelude
         let mut none_obj = IndexMap::new();
@@ -819,36 +819,36 @@ impl VM {
         none_obj.insert("__variant__".to_string(), self.alloc_string("None"));
         let none_ref = self.gc.alloc(ObjKind::Object(none_obj));
         self.globals
-            .insert("None".to_string(), Value::Obj(none_ref));
+            .insert("None".to_string(), Value::obj(none_ref));
 
         let some_native = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
             name: "Some".to_string(),
         }));
         self.globals
-            .insert("Some".to_string(), Value::Obj(some_native));
+            .insert("Some".to_string(), Value::obj(some_native));
     }
 
     pub(super) fn alloc_string(&mut self, s: &str) -> Value {
         let r = self.gc.alloc_string(s.to_string());
-        Value::Obj(r)
+        Value::obj(r)
     }
 
     pub(super) fn alloc_builtin(&mut self, name: &str) -> Value {
         let native = self.gc.alloc(ObjKind::NativeFunction(NativeFn {
             name: name.to_string(),
         }));
-        Value::Obj(native)
+        Value::obj(native)
     }
 
     fn constant_to_value(&mut self, constant: &Constant) -> Value {
         match constant {
-            Constant::Int(n) => Value::Int(*n),
-            Constant::Float(n) => Value::Float(*n),
-            Constant::Bool(b) => Value::Bool(*b),
-            Constant::Null => Value::Null,
+            Constant::Int(n) => Value::int(*n, &mut self.gc),
+            Constant::Float(n) => Value::float(*n),
+            Constant::Bool(b) => Value::bool_val(*b),
+            Constant::Null => Value::null(),
             Constant::Str(s) => {
                 let r = self.gc.alloc_string(s.clone());
-                Value::Obj(r)
+                Value::obj(r)
             }
         }
     }
@@ -950,7 +950,7 @@ impl VM {
                             _ => None,
                         })
                         .cloned()
-                        .unwrap_or(Value::Null);
+                        .unwrap_or(Value::null());
                     let shared = value_to_shared(&self.gc, &uv_val);
                     let child_val = shared_to_value(&mut child.gc, &shared);
                     let child_uv = child
@@ -963,7 +963,7 @@ impl VM {
                     upvalues: child_upvalues,
                 };
                 let r = child.gc.alloc(ObjKind::Closure(closure));
-                Value::Obj(r)
+                Value::obj(r)
             }
             ObjKind::Function(f) => {
                 let function = ObjFunction {
@@ -971,9 +971,9 @@ impl VM {
                     chunk: std::sync::Arc::clone(&f.chunk),
                 };
                 let r = child.gc.alloc(ObjKind::Function(function));
-                Value::Obj(r)
+                Value::obj(r)
             }
-            _ => Value::Null,
+            _ => Value::null(),
         }
     }
 
@@ -1018,7 +1018,7 @@ impl VM {
 
     fn ensure_registers(&mut self, needed: usize) {
         if needed > self.registers.len() {
-            self.registers.resize(needed, Value::Null);
+            self.registers.resize(needed, Value::null());
         }
     }
 
@@ -1091,7 +1091,7 @@ impl VM {
 
         loop {
             if self.frames.is_empty() {
-                return Ok(Value::Null);
+                return Ok(Value::null());
             }
 
             let frame_idx = self.frames.len() - 1;
@@ -1154,13 +1154,13 @@ impl VM {
                         self.registers[base + a as usize] = val;
                     }
                     OpCode::LoadNull => {
-                        self.registers[base + a as usize] = Value::Null;
+                        self.registers[base + a as usize] = Value::null();
                     }
                     OpCode::LoadTrue => {
-                        self.registers[base + a as usize] = Value::Bool(true);
+                        self.registers[base + a as usize] = Value::bool_val(true);
                     }
                     OpCode::LoadFalse => {
-                        self.registers[base + a as usize] = Value::Bool(false);
+                        self.registers[base + a as usize] = Value::bool_val(false);
                     }
                     OpCode::Move => {
                         self.registers[base + a as usize] = self.registers[base + b as usize];
@@ -1198,8 +1198,8 @@ impl VM {
                     OpCode::Neg => {
                         let src = &self.registers[base + b as usize];
                         self.registers[base + a as usize] = match src {
-                            Value::Int(n) => Value::Int(-n),
-                            Value::Float(n) => Value::Float(-n),
+                            Value::Int(n) => Value::small_int(-n),
+                            Value::Float(n) => Value::float(-n),
                             _ => return Err(VMError::new("cannot negate non-number")),
                         };
                     }
@@ -1207,13 +1207,13 @@ impl VM {
                         let left = &self.registers[base + b as usize];
                         let right = &self.registers[base + c as usize];
                         self.registers[base + a as usize] =
-                            Value::Bool(left.equals(right, &self.gc));
+                            Value::bool_val(left.equals(right, &self.gc));
                     }
                     OpCode::NotEq => {
                         let left = &self.registers[base + b as usize];
                         let right = &self.registers[base + c as usize];
                         self.registers[base + a as usize] =
-                            Value::Bool(!left.equals(right, &self.gc));
+                            Value::bool_val(!left.equals(right, &self.gc));
                     }
                     OpCode::Lt => {
                         let left = &self.registers[base + b as usize];
@@ -1242,16 +1242,16 @@ impl VM {
                     OpCode::And => {
                         let left = self.registers[base + b as usize].is_truthy(&self.gc);
                         let right = self.registers[base + c as usize].is_truthy(&self.gc);
-                        self.registers[base + a as usize] = Value::Bool(left && right);
+                        self.registers[base + a as usize] = Value::bool_val(left && right);
                     }
                     OpCode::Or => {
                         let left = self.registers[base + b as usize].is_truthy(&self.gc);
                         let right = self.registers[base + c as usize].is_truthy(&self.gc);
-                        self.registers[base + a as usize] = Value::Bool(left || right);
+                        self.registers[base + a as usize] = Value::bool_val(left || right);
                     }
                     OpCode::Not => {
                         let val = self.registers[base + b as usize].is_truthy(&self.gc);
-                        self.registers[base + a as usize] = Value::Bool(!val);
+                        self.registers[base + a as usize] = Value::bool_val(!val);
                     }
                     OpCode::GetGlobal => {
                         let name_const = &chunk.constants[bx as usize];
@@ -1347,7 +1347,7 @@ impl VM {
                     OpCode::ReturnNull => {
                         self.profiler.exit_function();
                         self.frames.pop();
-                        return Ok(Some(Value::Null));
+                        return Ok(Some(Value::null()));
                     }
                     OpCode::Closure => {
                         let proto = chunk.prototypes[bx as usize].clone();
@@ -1400,7 +1400,7 @@ impl VM {
                             upvalues: upvalue_refs,
                         };
                         let r = self.gc.alloc(ObjKind::Closure(closure));
-                        self.registers[base + a as usize] = Value::Obj(r);
+                        self.registers[base + a as usize] = Value::obj(r);
                     }
                     OpCode::GetUpvalue => {
                         let uv_idx = b as usize;
@@ -1446,7 +1446,7 @@ impl VM {
                             items.push(self.registers[start + i]);
                         }
                         let r = self.gc.alloc(ObjKind::Array(items));
-                        self.registers[base + a as usize] = Value::Obj(r);
+                        self.registers[base + a as usize] = Value::obj(r);
                     }
                     OpCode::NewObject => {
                         let start = base + b as usize;
@@ -1460,7 +1460,7 @@ impl VM {
                             }
                         }
                         let r = self.gc.alloc(ObjKind::Object(map));
-                        self.registers[base + a as usize] = Value::Obj(r);
+                        self.registers[base + a as usize] = Value::obj(r);
                     }
                     OpCode::GetField => {
                         let obj_val = &self.registers[base + b as usize];
@@ -1527,7 +1527,7 @@ impl VM {
                                     ObjKind::String(s) => match field.as_str() {
                                         "len" => {
                                             direct_result =
-                                                Some(Value::Int(s.chars().count() as i64));
+                                                Some(Value::small_int(s.chars().count() as i64));
                                             needs_alloc = None;
                                         }
                                         "upper" => {
@@ -1551,7 +1551,8 @@ impl VM {
                                     },
                                     ObjKind::Array(items) => match field.as_str() {
                                         "len" => {
-                                            direct_result = Some(Value::Int(items.len() as i64));
+                                            direct_result =
+                                                Some(Value::small_int(items.len() as i64));
                                             needs_alloc = None;
                                         }
                                         _ => {
@@ -1619,7 +1620,7 @@ impl VM {
                                         return Err(VMError::new("cannot index non-array"));
                                     }
                                 } else {
-                                    Value::Null
+                                    Value::null()
                                 }
                             }
                             (Value::Obj(r), Value::Obj(_key_ref)) => {
@@ -1628,12 +1629,12 @@ impl VM {
                                 })?;
                                 if let Some(o) = self.gc.get(*r) {
                                     if let ObjKind::Object(map) = &o.kind {
-                                        map.get(&key).cloned().unwrap_or(Value::Null)
+                                        map.get(&key).cloned().unwrap_or(Value::null())
                                     } else {
-                                        Value::Null
+                                        Value::null()
                                     }
                                 } else {
-                                    Value::Null
+                                    Value::null()
                                 }
                             }
                             _ => return Err(VMError::new("invalid index operation")),
@@ -1681,13 +1682,13 @@ impl VM {
                             }
                             _ => 0,
                         };
-                        self.registers[base + a as usize] = Value::Int(len);
+                        self.registers[base + a as usize] = Value::small_int(len);
                     }
                     OpCode::Concat => {
                         let left = self.registers[base + b as usize].display(&self.gc);
                         let right = self.registers[base + c as usize].display(&self.gc);
                         let r = self.gc.alloc_string(format!("{}{}", left, right));
-                        self.registers[base + a as usize] = Value::Obj(r);
+                        self.registers[base + a as usize] = Value::obj(r);
                     }
                     OpCode::Interpolate => {
                         let start = base + b as usize;
@@ -1697,7 +1698,7 @@ impl VM {
                             result.push_str(&self.registers[start + i].display(&self.gc));
                         }
                         let r = self.gc.alloc_string(result);
-                        self.registers[base + a as usize] = Value::Obj(r);
+                        self.registers[base + a as usize] = Value::obj(r);
                     }
                     OpCode::ExtractField => {
                         let obj = &self.registers[base + b as usize];
@@ -1706,7 +1707,7 @@ impl VM {
                             if let Some(o) = self.gc.get(*r) {
                                 if let ObjKind::Object(map) = &o.kind {
                                     self.registers[base + a as usize] =
-                                        map.get(&field_name).cloned().unwrap_or(Value::Null);
+                                        map.get(&field_name).cloned().unwrap_or(Value::null());
                                 }
                             }
                         }
@@ -1745,13 +1746,13 @@ impl VM {
                         let child_closure = if let Value::Obj(r) = &closure_val {
                             self.transfer_closure(*r, &mut sendable.0)
                         } else {
-                            Value::Null
+                            Value::null()
                         };
 
                         spawn_thread(sendable, child_closure, slot_clone);
 
                         let handle = self.gc.alloc(ObjKind::TaskHandle(result_slot));
-                        self.registers[base + a as usize] = Value::Obj(handle);
+                        self.registers[base + a as usize] = Value::obj(handle);
                     }
                     OpCode::Await => {
                         let src = self.registers[base + b as usize];
@@ -1857,7 +1858,7 @@ impl VM {
                         let child_closure = if let Value::Obj(r) = &closure_val {
                             self.transfer_closure(*r, &mut sendable.0)
                         } else {
-                            Value::Null
+                            Value::null()
                         };
 
                         spawn_schedule_thread(sendable, child_closure, Duration::from_secs(secs));
@@ -1880,7 +1881,7 @@ impl VM {
                         let child_closure = if let Value::Obj(r) = &closure_val {
                             self.transfer_closure(*r, &mut sendable.0)
                         } else {
-                            Value::Null
+                            Value::null()
                         };
 
                         spawn_watch_thread(sendable, child_closure, path);
@@ -1982,11 +1983,11 @@ impl VM {
                                 if let Some(text) = content {
                                     self.registers[base + a as usize] = self.alloc_string(&text);
                                 } else {
-                                    self.registers[base + a as usize] = Value::Null;
+                                    self.registers[base + a as usize] = Value::null();
                                 }
                             }
                             Ok(_) => {
-                                self.registers[base + a as usize] = Value::Null;
+                                self.registers[base + a as usize] = Value::null();
                             }
                             Err(e) => {
                                 return Err(VMError::new(&format!("ask error: {}", e)));
@@ -1996,7 +1997,7 @@ impl VM {
                     OpCode::Freeze => {
                         let src = self.registers[base + b as usize];
                         let frozen_ref = self.gc.alloc(ObjKind::Frozen(src));
-                        self.registers[base + a as usize] = Value::Obj(frozen_ref);
+                        self.registers[base + a as usize] = Value::obj(frozen_ref);
                     }
                     _ => {
                         return Err(VMError::new(&format!("unknown opcode: {}", op)));
@@ -2163,9 +2164,9 @@ impl VM {
                                         && result >= i64::MIN as f64
                                         && result <= i64::MAX as f64
                                     {
-                                        Value::Int(result as i64)
+                                        Value::small_int(result as i64)
                                     } else {
-                                        Value::Float(result)
+                                        Value::float(result)
                                     }
                                 } else {
                                     let mut raw_args: Vec<i64> = Vec::new();
@@ -2190,9 +2191,9 @@ impl VM {
                                     let result: i64 =
                                         unsafe { jit_call_i64(entry.ptr, &raw_args)? };
                                     if entry.returns_string {
-                                        Value::Obj(GcRef(result as usize))
+                                        Value::obj(GcRef(result as usize))
                                     } else {
-                                        Value::Int(result)
+                                        Value::small_int(result)
                                     }
                                 };
                                 self.profiler.exit_function();
@@ -2214,7 +2215,7 @@ impl VM {
                             }
                         }
                         for i in args.len()..arity {
-                            self.registers[new_base + i] = Value::Null;
+                            self.registers[new_base + i] = Value::null();
                         }
 
                         self.frames.push(CallFrame::new(*r, new_base, frame_size));
@@ -2307,7 +2308,7 @@ impl VM {
             self.alloc_string(Self::classify_error_type(&err.message)),
         );
         let err_ref = self.gc.alloc(ObjKind::Object(err_obj));
-        Value::Obj(err_ref)
+        Value::obj(err_ref)
     }
 
     fn handle_runtime_error(&mut self, err: VMError) -> Result<usize, VMError> {
@@ -2383,16 +2384,16 @@ impl VM {
 
     pub(super) fn convert_interp_value(&mut self, v: &crate::interpreter::Value) -> Value {
         match v {
-            crate::interpreter::Value::Int(n) => Value::Int(*n),
-            crate::interpreter::Value::Float(n) => Value::Float(*n),
-            crate::interpreter::Value::Bool(b) => Value::Bool(*b),
-            crate::interpreter::Value::Null => Value::Null,
+            crate::interpreter::Value::Int(n) => Value::int(*n, &mut self.gc),
+            crate::interpreter::Value::Float(n) => Value::float(*n),
+            crate::interpreter::Value::Bool(b) => Value::bool_val(*b),
+            crate::interpreter::Value::Null => Value::null(),
             crate::interpreter::Value::String(s) => self.alloc_string(s),
             crate::interpreter::Value::Array(items) => {
                 let vm_items: Vec<Value> =
                     items.iter().map(|i| self.convert_interp_value(i)).collect();
                 let r = self.gc.alloc(ObjKind::Array(vm_items));
-                Value::Obj(r)
+                Value::obj(r)
             }
             crate::interpreter::Value::Object(map) => {
                 let mut vm_map = IndexMap::new();
@@ -2400,9 +2401,9 @@ impl VM {
                     vm_map.insert(k.clone(), self.convert_interp_value(val));
                 }
                 let r = self.gc.alloc(ObjKind::Object(vm_map));
-                Value::Obj(r)
+                Value::obj(r)
             }
-            _ => Value::Null,
+            _ => Value::null(),
         }
     }
 
@@ -2410,47 +2411,47 @@ impl VM {
         match (left, right) {
             (Value::Int(a), Value::Int(b)) => match op {
                 OpCode::Add => match a.checked_add(*b) {
-                    Some(r) => Ok(Value::Int(r)),
-                    None => Ok(Value::Float(*a as f64 + *b as f64)),
+                    Some(r) => Ok(Value::int(r, &mut self.gc)),
+                    None => Ok(Value::float(*a as f64 + *b as f64)),
                 },
                 OpCode::Sub => match a.checked_sub(*b) {
-                    Some(r) => Ok(Value::Int(r)),
-                    None => Ok(Value::Float(*a as f64 - *b as f64)),
+                    Some(r) => Ok(Value::int(r, &mut self.gc)),
+                    None => Ok(Value::float(*a as f64 - *b as f64)),
                 },
                 OpCode::Mul => match a.checked_mul(*b) {
-                    Some(r) => Ok(Value::Int(r)),
-                    None => Ok(Value::Float(*a as f64 * *b as f64)),
+                    Some(r) => Ok(Value::int(r, &mut self.gc)),
+                    None => Ok(Value::float(*a as f64 * *b as f64)),
                 },
                 OpCode::Div => {
                     if *b == 0 {
                         return Err(VMError::new("division by zero"));
                     }
-                    Ok(Value::Int(a / b))
+                    Ok(Value::int(a / b, &mut self.gc))
                 }
                 OpCode::Mod => {
                     if *b == 0 {
                         return Err(VMError::new("modulo by zero"));
                     }
-                    Ok(Value::Int(a % b))
+                    Ok(Value::int(a % b, &mut self.gc))
                 }
                 _ => Err(VMError::new("invalid operation")),
             },
             (Value::Float(a), Value::Float(b)) => match op {
-                OpCode::Add => Ok(Value::Float(a + b)),
-                OpCode::Sub => Ok(Value::Float(a - b)),
-                OpCode::Mul => Ok(Value::Float(a * b)),
-                OpCode::Div => Ok(Value::Float(a / b)),
-                OpCode::Mod => Ok(Value::Float(a % b)),
+                OpCode::Add => Ok(Value::float(a + b)),
+                OpCode::Sub => Ok(Value::float(a - b)),
+                OpCode::Mul => Ok(Value::float(a * b)),
+                OpCode::Div => Ok(Value::float(a / b)),
+                OpCode::Mod => Ok(Value::float(a % b)),
                 _ => Err(VMError::new("invalid operation")),
             },
-            (Value::Int(a), Value::Float(_b)) => self.arith_op(&Value::Float(*a as f64), right, op),
-            (Value::Float(_a), Value::Int(b)) => self.arith_op(left, &Value::Float(*b as f64), op),
+            (Value::Int(a), Value::Float(_b)) => self.arith_op(&Value::float(*a as f64), right, op),
+            (Value::Float(_a), Value::Int(b)) => self.arith_op(left, &Value::float(*b as f64), op),
             // String concatenation
             (Value::Obj(_), _) | (_, Value::Obj(_)) if op == OpCode::Add => {
                 let ls = left.display(&self.gc);
                 let rs = right.display(&self.gc);
                 let r = self.gc.alloc_string(format!("{}{}", ls, rs));
-                Ok(Value::Obj(r))
+                Ok(Value::obj(r))
             }
             _ => Err(VMError::new(&format!(
                 "cannot apply {:?} to {} and {}",
@@ -2471,7 +2472,7 @@ impl VM {
                     OpCode::GtEq => a >= b,
                     _ => false,
                 };
-                Ok(Value::Bool(result))
+                Ok(Value::bool_val(result))
             }
             (Value::Float(a), Value::Float(b)) => {
                 let result = match op {
@@ -2481,13 +2482,13 @@ impl VM {
                     OpCode::GtEq => a >= b,
                     _ => false,
                 };
-                Ok(Value::Bool(result))
+                Ok(Value::bool_val(result))
             }
             (Value::Int(a), Value::Float(_b)) => {
-                self.compare_op(&Value::Float(*a as f64), right, op)
+                self.compare_op(&Value::float(*a as f64), right, op)
             }
             (Value::Float(_a), Value::Int(b)) => {
-                self.compare_op(left, &Value::Float(*b as f64), op)
+                self.compare_op(left, &Value::float(*b as f64), op)
             }
             _ => Err(VMError::new("cannot compare non-numbers")),
         }

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -854,8 +854,8 @@ impl VM {
     }
 
     pub(super) fn get_string(&self, val: &Value) -> Option<String> {
-        if let Value::Obj(r) = val {
-            if let Some(obj) = self.gc.get(*r) {
+        if let Some(r) = val.as_obj() {
+            if let Some(obj) = self.gc.get(r) {
                 if let ObjKind::String(s) = &obj.kind {
                     return Some(s.clone());
                 }
@@ -875,7 +875,7 @@ impl VM {
         // these would overwrite the child's freshly-registered builtins.
         for (name, val) in &self.globals {
             let shared = value_to_shared(&self.gc, val);
-            if matches!(shared, SharedValue::Null) && !matches!(val, Value::Null) {
+            if matches!(shared, SharedValue::Null) && !val.is_null() {
                 continue;
             }
             let child_val = shared_to_value(&mut child.gc, &shared);
@@ -886,7 +886,7 @@ impl VM {
             let mut child_methods = IndexMap::new();
             for (k, v) in methods {
                 let shared = value_to_shared(&self.gc, v);
-                if matches!(shared, SharedValue::Null) && !matches!(v, Value::Null) {
+                if matches!(shared, SharedValue::Null) && !v.is_null() {
                     continue;
                 }
                 child_methods.insert(k.clone(), shared_to_value(&mut child.gc, &shared));
@@ -897,7 +897,7 @@ impl VM {
             let mut child_methods = IndexMap::new();
             for (k, v) in methods {
                 let shared = value_to_shared(&self.gc, v);
-                if matches!(shared, SharedValue::Null) && !matches!(v, Value::Null) {
+                if matches!(shared, SharedValue::Null) && !v.is_null() {
                     continue;
                 }
                 child_methods.insert(k.clone(), shared_to_value(&mut child.gc, &shared));
@@ -911,7 +911,7 @@ impl VM {
             let mut child_defaults = IndexMap::new();
             for (k, v) in defaults {
                 let shared = value_to_shared(&self.gc, v);
-                if matches!(shared, SharedValue::Null) && !matches!(v, Value::Null) {
+                if matches!(shared, SharedValue::Null) && !v.is_null() {
                     continue;
                 }
                 child_defaults.insert(k.clone(), shared_to_value(&mut child.gc, &shared));
@@ -1196,10 +1196,10 @@ impl VM {
                             self.arith_op(&left, &right, OpCode::Mod)?;
                     }
                     OpCode::Neg => {
-                        let src = &self.registers[base + b as usize];
-                        self.registers[base + a as usize] = match src {
-                            Value::Int(n) => Value::small_int(-n),
-                            Value::Float(n) => Value::float(-n),
+                        let src = self.registers[base + b as usize];
+                        self.registers[base + a as usize] = match src.classify(&self.gc) {
+                            ValueKind::Int(n) => Value::small_int(-n),
+                            ValueKind::Float(n) => Value::float(-n),
                             _ => return Err(VMError::new("cannot negate non-number")),
                         };
                     }
@@ -1465,8 +1465,7 @@ impl VM {
                     OpCode::GetField => {
                         let obj_val = &self.registers[base + b as usize];
                         let field_const = &chunk.constants[c as usize];
-                        if let (Value::Obj(r), Constant::Str(field)) = (obj_val, field_const) {
-                            let r = *r;
+                        if let (Some(r), Constant::Str(field)) = (obj_val.as_obj(), field_const) {
                             let needs_alloc: Option<String>;
                             let direct_result: Option<Value>;
                             if let Some(obj) = self.gc.get(r) {
@@ -1483,12 +1482,13 @@ impl VM {
                                                 self.embedded_fields.get(&type_name).cloned()
                                             {
                                                 for (embed_field, _) in embeds {
-                                                    let Some(Value::Obj(embed_ref)) =
-                                                        map.get(&embed_field)
+                                                    let Some(embed_ref) = map
+                                                        .get(&embed_field)
+                                                        .and_then(|v| v.as_obj())
                                                     else {
                                                         continue;
                                                     };
-                                                    let Some(embed_obj) = self.gc.get(*embed_ref)
+                                                    let Some(embed_obj) = self.gc.get(embed_ref)
                                                     else {
                                                         continue;
                                                     };
@@ -1587,12 +1587,12 @@ impl VM {
                         let field_const = &chunk.constants[b as usize];
                         let val = self.registers[base + c as usize];
                         if let Constant::Str(field) = field_const {
-                            let obj_ref = if let Value::Obj(r) = &self.registers[base + a as usize]
-                            {
-                                *r
-                            } else {
-                                return Err(VMError::new("cannot set field on non-object"));
-                            };
+                            let obj_ref =
+                                if let Some(r) = self.registers[base + a as usize].as_obj() {
+                                    r
+                                } else {
+                                    return Err(VMError::new("cannot set field on non-object"));
+                                };
                             if let Some(obj) = self.gc.get(obj_ref) {
                                 if matches!(&obj.kind, ObjKind::Frozen(_)) {
                                     return Err(VMError::new("cannot mutate a frozen value"));
@@ -1608,12 +1608,12 @@ impl VM {
                     OpCode::GetIndex => {
                         let obj = self.registers[base + b as usize];
                         let idx = self.registers[base + c as usize];
-                        let result = match (&obj, &idx) {
-                            (Value::Obj(r), Value::Int(i)) => {
-                                if let Some(o) = self.gc.get(*r) {
+                        let result = if let Some(r) = obj.as_obj() {
+                            if let Some(i) = idx.as_int(&self.gc) {
+                                if let Some(o) = self.gc.get(r) {
                                     if let ObjKind::Array(items) = &o.kind {
                                         items
-                                            .get(*i as usize)
+                                            .get(i as usize)
                                             .cloned()
                                             .ok_or_else(|| VMError::new("index out of bounds"))?
                                     } else {
@@ -1622,12 +1622,11 @@ impl VM {
                                 } else {
                                     Value::null()
                                 }
-                            }
-                            (Value::Obj(r), Value::Obj(_key_ref)) => {
+                            } else if idx.as_obj().is_some() {
                                 let key = self.get_string(&idx).ok_or_else(|| {
                                     VMError::new("index must be string for objects")
                                 })?;
-                                if let Some(o) = self.gc.get(*r) {
+                                if let Some(o) = self.gc.get(r) {
                                     if let ObjKind::Object(map) = &o.kind {
                                         map.get(&key).cloned().unwrap_or(Value::null())
                                     } else {
@@ -1636,51 +1635,51 @@ impl VM {
                                 } else {
                                     Value::null()
                                 }
+                            } else {
+                                return Err(VMError::new("invalid index operation"));
                             }
-                            _ => return Err(VMError::new("invalid index operation")),
+                        } else {
+                            return Err(VMError::new("invalid index operation"));
                         };
                         self.registers[base + a as usize] = result;
                     }
                     OpCode::SetIndex => {
                         let idx = self.registers[base + b as usize];
                         let val = self.registers[base + c as usize];
-                        if let Value::Obj(r) = &self.registers[base + a as usize] {
-                            let r = *r;
+                        if let Some(r) = self.registers[base + a as usize].as_obj() {
                             let key_str = self.get_string(&idx);
+                            let idx_int = idx.as_int(&self.gc);
                             if let Some(obj) = self.gc.get_mut(r) {
-                                match (&mut obj.kind, &idx) {
-                                    (ObjKind::Array(items), Value::Int(i)) => {
-                                        let i = *i as usize;
+                                if let Some(i) = idx_int {
+                                    if let ObjKind::Array(items) = &mut obj.kind {
+                                        let i = i as usize;
                                         if i < items.len() {
                                             items[i] = val;
                                         }
                                     }
-                                    (ObjKind::Object(map), _) => {
-                                        if let Some(key) = key_str {
-                                            map.insert(key, val);
-                                        }
+                                } else if let ObjKind::Object(map) = &mut obj.kind {
+                                    if let Some(key) = key_str {
+                                        map.insert(key, val);
                                     }
-                                    _ => {}
                                 }
                             }
                         }
                     }
                     OpCode::Len => {
-                        let src = &self.registers[base + b as usize];
-                        let len = match src {
-                            Value::Obj(r) => {
-                                if let Some(obj) = self.gc.get(*r) {
-                                    match &obj.kind {
-                                        ObjKind::String(s) => s.chars().count() as i64,
-                                        ObjKind::Array(a) => a.len() as i64,
-                                        ObjKind::Object(o) => o.len() as i64,
-                                        _ => 0,
-                                    }
-                                } else {
-                                    0
+                        let src = self.registers[base + b as usize];
+                        let len = if let Some(r) = src.as_obj() {
+                            if let Some(obj) = self.gc.get(r) {
+                                match &obj.kind {
+                                    ObjKind::String(s) => s.chars().count() as i64,
+                                    ObjKind::Array(a) => a.len() as i64,
+                                    ObjKind::Object(o) => o.len() as i64,
+                                    _ => 0,
                                 }
+                            } else {
+                                0
                             }
-                            _ => 0,
+                        } else {
+                            0
                         };
                         self.registers[base + a as usize] = Value::small_int(len);
                     }
@@ -1703,8 +1702,8 @@ impl VM {
                     OpCode::ExtractField => {
                         let obj = &self.registers[base + b as usize];
                         let field_name = format!("_{}", c);
-                        if let Value::Obj(r) = obj {
-                            if let Some(o) = self.gc.get(*r) {
+                        if let Some(r) = obj.as_obj() {
+                            if let Some(o) = self.gc.get(r) {
                                 if let ObjKind::Object(map) = &o.kind {
                                     self.registers[base + a as usize] =
                                         map.get(&field_name).cloned().unwrap_or(Value::null());
@@ -1713,9 +1712,9 @@ impl VM {
                         }
                     }
                     OpCode::Try => {
-                        let src = &self.registers[base + b as usize];
-                        if let Value::Obj(r) = src {
-                            if let Some(obj) = self.gc.get(*r) {
+                        let src = self.registers[base + b as usize];
+                        if let Some(r) = src.as_obj() {
+                            if let Some(obj) = self.gc.get(r) {
                                 match &obj.kind {
                                     ObjKind::ResultOk(v) => {
                                         self.registers[base + a as usize] = *v;
@@ -1743,8 +1742,8 @@ impl VM {
                         let slot_clone = result_slot.clone();
 
                         let mut sendable = self.fork_for_spawn();
-                        let child_closure = if let Value::Obj(r) = &closure_val {
-                            self.transfer_closure(*r, &mut sendable.0)
+                        let child_closure = if let Some(r) = closure_val.as_obj() {
+                            self.transfer_closure(r, &mut sendable.0)
                         } else {
                             Value::null()
                         };
@@ -1757,8 +1756,8 @@ impl VM {
                     OpCode::Await => {
                         let src = self.registers[base + b as usize];
                         // Extract the Arc first, releasing the GC borrow
-                        let maybe_slot = if let Value::Obj(r) = &src {
-                            self.gc.get(*r).and_then(|obj| {
+                        let maybe_slot = if let Some(r) = src.as_obj() {
+                            self.gc.get(r).and_then(|obj| {
                                 if let ObjKind::TaskHandle(slot) = &obj.kind {
                                     Some(slot.clone())
                                 } else {
@@ -1801,10 +1800,13 @@ impl VM {
                         self.frames[frame_idx].handlers.pop();
                     }
                     OpCode::PushTimeout => {
-                        let seconds = match &self.registers[base + a as usize] {
-                            Value::Int(n) => (*n).max(0) as u64,
-                            Value::Float(n) => n.max(0.0) as u64,
-                            _ => 5,
+                        let timeout_val = self.registers[base + a as usize];
+                        let seconds = if let Some(n) = timeout_val.as_int(&self.gc) {
+                            n.max(0) as u64
+                        } else if let Some(n) = timeout_val.as_float() {
+                            n.max(0.0) as u64
+                        } else {
+                            5
                         };
                         let catch_ip = {
                             let frame = &self.frames[frame_idx];
@@ -1824,14 +1826,14 @@ impl VM {
                     }
                     OpCode::Schedule => {
                         let closure_val = self.registers[base + a as usize];
-                        let interval_val = &self.registers[base + b as usize];
-                        let secs = match interval_val {
-                            Value::Int(n) if *n > 0 => {
+                        let interval_val = self.registers[base + b as usize];
+                        let secs = if let Some(n) = interval_val.as_int(&self.gc) {
+                            if n > 0 {
                                 // Read unit string from register C
-                                let unit_val = &self.registers[base + c as usize];
-                                let unit_str = if let Value::Obj(r) = unit_val {
+                                let unit_val = self.registers[base + c as usize];
+                                let unit_str = if let Some(r) = unit_val.as_obj() {
                                     self.gc
-                                        .get(*r)
+                                        .get(r)
                                         .and_then(|o| match &o.kind {
                                             ObjKind::String(s) => Some(s.clone()),
                                             _ => None,
@@ -1841,22 +1843,22 @@ impl VM {
                                     String::new()
                                 };
                                 match unit_str.as_str() {
-                                    "minutes" => *n as u64 * 60,
-                                    "hours" => *n as u64 * 3600,
-                                    _ => *n as u64, // "seconds" or default
+                                    "minutes" => n as u64 * 60,
+                                    "hours" => n as u64 * 3600,
+                                    _ => n as u64, // "seconds" or default
                                 }
-                            }
-                            Value::Int(_) => {
+                            } else {
                                 return Err(VMError::new(
                                     "schedule interval must be a positive integer",
                                 ));
                             }
-                            _ => 60, // Non-integer defaults to 60s (matches interpreter)
+                        } else {
+                            60 // Non-integer defaults to 60s (matches interpreter)
                         };
 
                         let mut sendable = self.fork_for_spawn();
-                        let child_closure = if let Value::Obj(r) = &closure_val {
-                            self.transfer_closure(*r, &mut sendable.0)
+                        let child_closure = if let Some(r) = closure_val.as_obj() {
+                            self.transfer_closure(r, &mut sendable.0)
                         } else {
                             Value::null()
                         };
@@ -1865,9 +1867,9 @@ impl VM {
                     }
                     OpCode::Watch => {
                         let closure_val = self.registers[base + a as usize];
-                        let path_val = &self.registers[base + b as usize];
-                        let path = if let Value::Obj(r) = path_val {
-                            self.gc.get(*r).and_then(|o| match &o.kind {
+                        let path_val = self.registers[base + b as usize];
+                        let path = if let Some(r) = path_val.as_obj() {
+                            self.gc.get(r).and_then(|o| match &o.kind {
                                 ObjKind::String(s) => Some(s.clone()),
                                 _ => None,
                             })
@@ -1878,8 +1880,8 @@ impl VM {
                             path.ok_or_else(|| VMError::new("watch requires a string path"))?;
 
                         let mut sendable = self.fork_for_spawn();
-                        let child_closure = if let Value::Obj(r) = &closure_val {
-                            self.transfer_closure(*r, &mut sendable.0)
+                        let child_closure = if let Some(r) = closure_val.as_obj() {
+                            self.transfer_closure(r, &mut sendable.0)
                         } else {
                             Value::null()
                         };
@@ -1888,19 +1890,19 @@ impl VM {
                     }
                     OpCode::Must => {
                         let src = self.registers[base + b as usize];
-                        let result = match &src {
-                            Value::Null => {
-                                return Err(VMError::new("must failed: got null"));
-                            }
-                            Value::Obj(r) => match self.gc.get(*r).map(|o| &o.kind) {
+                        let result = if src.is_null() {
+                            return Err(VMError::new("must failed: got null"));
+                        } else if let Some(r) = src.as_obj() {
+                            match self.gc.get(r).map(|o| &o.kind) {
                                 Some(ObjKind::ResultErr(v)) => {
                                     let msg = v.display(&self.gc);
                                     return Err(VMError::new(&format!("must failed: {}", msg)));
                                 }
                                 Some(ObjKind::ResultOk(v)) => *v,
                                 _ => src,
-                            },
-                            _ => src,
+                            }
+                        } else {
+                            src
                         };
                         self.registers[base + a as usize] = result;
                     }
@@ -2032,13 +2034,13 @@ impl VM {
                 let scan_limit = max_reg.min(self.registers.len());
                 let mut roots = Vec::with_capacity(scan_limit / 4);
                 for r in &self.registers[..scan_limit] {
-                    if let Value::Obj(gr) = r {
-                        roots.push(*gr);
+                    if let Some(gr) = r.as_obj() {
+                        roots.push(gr);
                     }
                 }
                 for v in self.globals.values() {
-                    if let Value::Obj(gr) = v {
-                        roots.push(*gr);
+                    if let Some(gr) = v.as_obj() {
+                        roots.push(gr);
                     }
                 }
                 for frame in &self.frames {
@@ -2049,22 +2051,22 @@ impl VM {
                 }
                 for methods in self.method_tables.values() {
                     for v in methods.values() {
-                        if let Value::Obj(gr) = v {
-                            roots.push(*gr);
+                        if let Some(gr) = v.as_obj() {
+                            roots.push(gr);
                         }
                     }
                 }
                 for methods in self.static_methods.values() {
                     for v in methods.values() {
-                        if let Value::Obj(gr) = v {
-                            roots.push(*gr);
+                        if let Some(gr) = v.as_obj() {
+                            roots.push(gr);
                         }
                     }
                 }
                 for defaults in self.struct_defaults.values() {
                     for v in defaults.values() {
-                        if let Value::Obj(gr) = v {
-                            roots.push(*gr);
+                        if let Some(gr) = v.as_obj() {
+                            roots.push(gr);
                         }
                     }
                 }
@@ -2074,12 +2076,12 @@ impl VM {
     }
 
     pub fn call_value(&mut self, func: Value, args: Vec<Value>) -> Result<Value, VMError> {
-        match &func {
-            Value::Obj(r) => {
-                let obj = self
-                    .gc
-                    .get(*r)
-                    .ok_or_else(|| VMError::new("null function"))?;
+        if let Some(r) = func.as_obj() {
+            let obj = self
+                .gc
+                .get(r)
+                .ok_or_else(|| VMError::new("null function"))?;
+            {
                 match &obj.kind {
                     ObjKind::Closure(closure) => {
                         let chunk = closure.function.chunk.clone();
@@ -2145,17 +2147,20 @@ impl VM {
                                 let result_val = if entry.uses_float {
                                     let raw_args: Vec<f64> = args
                                         .iter()
-                                        .map(|v| match v {
-                                            Value::Int(n) => *n as f64,
-                                            Value::Float(f) => *f,
-                                            Value::Bool(b) => {
-                                                if *b {
+                                        .map(|v| {
+                                            if let Some(n) = v.as_inline_int() {
+                                                n as f64
+                                            } else if let Some(f) = v.as_float() {
+                                                f
+                                            } else if let Some(b) = v.as_bool() {
+                                                if b {
                                                     1.0
                                                 } else {
                                                     0.0
                                                 }
+                                            } else {
+                                                0.0
                                             }
-                                            _ => 0.0,
                                         })
                                         .collect();
                                     let result: f64 =
@@ -2175,17 +2180,18 @@ impl VM {
                                         raw_args.push(self as *mut VM as *mut () as i64);
                                     }
                                     for v in &args {
-                                        raw_args.push(match v {
-                                            Value::Int(n) => *n,
-                                            Value::Bool(b) => {
-                                                if *b {
-                                                    1
-                                                } else {
-                                                    0
-                                                }
+                                        raw_args.push(if let Some(n) = v.as_inline_int() {
+                                            n
+                                        } else if let Some(b) = v.as_bool() {
+                                            if b {
+                                                1
+                                            } else {
+                                                0
                                             }
-                                            Value::Obj(GcRef(idx)) => *idx as i64,
-                                            _ => 0,
+                                        } else if let Some(r) = v.as_obj() {
+                                            r.0 as i64
+                                        } else {
+                                            0
                                         });
                                     }
                                     let result: i64 =
@@ -2218,7 +2224,7 @@ impl VM {
                             self.registers[new_base + i] = Value::null();
                         }
 
-                        self.frames.push(CallFrame::new(*r, new_base, frame_size));
+                        self.frames.push(CallFrame::new(r, new_base, frame_size));
                         let boundary = self.frames.len() - 1;
                         self.run_until(boundary)
                     }
@@ -2237,7 +2243,8 @@ impl VM {
                     _ => Err(VMError::new("cannot call non-function")),
                 }
             }
-            _ => Err(VMError::new("cannot call non-function")),
+        } else {
+            Err(VMError::new("cannot call non-function"))
         }
     }
 
@@ -2344,13 +2351,13 @@ impl VM {
     }
 
     pub(super) fn convert_to_interp_val(&self, v: &Value) -> crate::interpreter::Value {
-        match v {
-            Value::Int(n) => crate::interpreter::Value::Int(*n),
-            Value::Float(n) => crate::interpreter::Value::Float(*n),
-            Value::Bool(b) => crate::interpreter::Value::Bool(*b),
-            Value::Null => crate::interpreter::Value::Null,
-            Value::Obj(r) => {
-                if let Some(obj) = self.gc.get(*r) {
+        match v.classify(&self.gc) {
+            ValueKind::Int(n) => crate::interpreter::Value::Int(n),
+            ValueKind::Float(n) => crate::interpreter::Value::Float(n),
+            ValueKind::Bool(b) => crate::interpreter::Value::Bool(b),
+            ValueKind::Null => crate::interpreter::Value::Null,
+            ValueKind::Obj(r) => {
+                if let Some(obj) = self.gc.get(r) {
                     match &obj.kind {
                         ObjKind::String(s) => crate::interpreter::Value::String(s.clone()),
                         ObjKind::Array(items) => {
@@ -2408,35 +2415,35 @@ impl VM {
     }
 
     fn arith_op(&mut self, left: &Value, right: &Value, op: OpCode) -> Result<Value, VMError> {
-        match (left, right) {
-            (Value::Int(a), Value::Int(b)) => match op {
-                OpCode::Add => match a.checked_add(*b) {
+        match (left.classify(&self.gc), right.classify(&self.gc)) {
+            (ValueKind::Int(a), ValueKind::Int(b)) => match op {
+                OpCode::Add => match a.checked_add(b) {
                     Some(r) => Ok(Value::int(r, &mut self.gc)),
-                    None => Ok(Value::float(*a as f64 + *b as f64)),
+                    None => Ok(Value::float(a as f64 + b as f64)),
                 },
-                OpCode::Sub => match a.checked_sub(*b) {
+                OpCode::Sub => match a.checked_sub(b) {
                     Some(r) => Ok(Value::int(r, &mut self.gc)),
-                    None => Ok(Value::float(*a as f64 - *b as f64)),
+                    None => Ok(Value::float(a as f64 - b as f64)),
                 },
-                OpCode::Mul => match a.checked_mul(*b) {
+                OpCode::Mul => match a.checked_mul(b) {
                     Some(r) => Ok(Value::int(r, &mut self.gc)),
-                    None => Ok(Value::float(*a as f64 * *b as f64)),
+                    None => Ok(Value::float(a as f64 * b as f64)),
                 },
                 OpCode::Div => {
-                    if *b == 0 {
+                    if b == 0 {
                         return Err(VMError::new("division by zero"));
                     }
                     Ok(Value::int(a / b, &mut self.gc))
                 }
                 OpCode::Mod => {
-                    if *b == 0 {
+                    if b == 0 {
                         return Err(VMError::new("modulo by zero"));
                     }
                     Ok(Value::int(a % b, &mut self.gc))
                 }
                 _ => Err(VMError::new("invalid operation")),
             },
-            (Value::Float(a), Value::Float(b)) => match op {
+            (ValueKind::Float(a), ValueKind::Float(b)) => match op {
                 OpCode::Add => Ok(Value::float(a + b)),
                 OpCode::Sub => Ok(Value::float(a - b)),
                 OpCode::Mul => Ok(Value::float(a * b)),
@@ -2444,10 +2451,14 @@ impl VM {
                 OpCode::Mod => Ok(Value::float(a % b)),
                 _ => Err(VMError::new("invalid operation")),
             },
-            (Value::Int(a), Value::Float(_b)) => self.arith_op(&Value::float(*a as f64), right, op),
-            (Value::Float(_a), Value::Int(b)) => self.arith_op(left, &Value::float(*b as f64), op),
+            (ValueKind::Int(a), ValueKind::Float(_b)) => {
+                self.arith_op(&Value::float(a as f64), right, op)
+            }
+            (ValueKind::Float(_a), ValueKind::Int(b)) => {
+                self.arith_op(left, &Value::float(b as f64), op)
+            }
             // String concatenation
-            (Value::Obj(_), _) | (_, Value::Obj(_)) if op == OpCode::Add => {
+            (ValueKind::Obj(_), _) | (_, ValueKind::Obj(_)) if op == OpCode::Add => {
                 let ls = left.display(&self.gc);
                 let rs = right.display(&self.gc);
                 let r = self.gc.alloc_string(format!("{}{}", ls, rs));
@@ -2463,8 +2474,8 @@ impl VM {
     }
 
     fn compare_op(&self, left: &Value, right: &Value, op: OpCode) -> Result<Value, VMError> {
-        match (left, right) {
-            (Value::Int(a), Value::Int(b)) => {
+        match (left.classify(&self.gc), right.classify(&self.gc)) {
+            (ValueKind::Int(a), ValueKind::Int(b)) => {
                 let result = match op {
                     OpCode::Lt => a < b,
                     OpCode::Gt => a > b,
@@ -2474,7 +2485,7 @@ impl VM {
                 };
                 Ok(Value::bool_val(result))
             }
-            (Value::Float(a), Value::Float(b)) => {
+            (ValueKind::Float(a), ValueKind::Float(b)) => {
                 let result = match op {
                     OpCode::Lt => a < b,
                     OpCode::Gt => a > b,
@@ -2484,11 +2495,11 @@ impl VM {
                 };
                 Ok(Value::bool_val(result))
             }
-            (Value::Int(a), Value::Float(_b)) => {
-                self.compare_op(&Value::float(*a as f64), right, op)
+            (ValueKind::Int(a), ValueKind::Float(_b)) => {
+                self.compare_op(&Value::float(a as f64), right, op)
             }
-            (Value::Float(_a), Value::Int(b)) => {
-                self.compare_op(left, &Value::float(*b as f64), op)
+            (ValueKind::Float(_a), ValueKind::Int(b)) => {
+                self.compare_op(left, &Value::float(b as f64), op)
             }
             _ => Err(VMError::new("cannot compare non-numbers")),
         }

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1198,7 +1198,10 @@ impl VM {
                     OpCode::Neg => {
                         let src = self.registers[base + b as usize];
                         self.registers[base + a as usize] = match src.classify(&self.gc) {
-                            ValueKind::Int(n) => Value::small_int(-n),
+                            ValueKind::Int(n) => match n.checked_neg() {
+                                Some(neg) => Value::int(neg, &mut self.gc),
+                                None => Value::float(-(n as f64)),
+                            },
                             ValueKind::Float(n) => Value::float(-n),
                             _ => return Err(VMError::new("cannot negate non-number")),
                         };
@@ -2169,7 +2172,7 @@ impl VM {
                                         && result >= i64::MIN as f64
                                         && result <= i64::MAX as f64
                                     {
-                                        Value::small_int(result as i64)
+                                        Value::int(result as i64, &mut self.gc)
                                     } else {
                                         Value::float(result)
                                     }
@@ -2199,7 +2202,7 @@ impl VM {
                                     if entry.returns_string {
                                         Value::obj(GcRef(result as usize))
                                     } else {
-                                        Value::small_int(result)
+                                        Value::int(result, &mut self.gc)
                                     }
                                 };
                                 self.profiler.exit_function();

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -1,5 +1,6 @@
 use super::bytecode::Chunk;
 use super::gc::Gc;
+use super::nanbox::NanBoxedValue;
 use indexmap::IndexMap;
 use std::fmt;
 use std::sync::mpsc::{Receiver, Sender, SyncSender};
@@ -58,12 +59,12 @@ pub enum SharedValue {
 /// Convert a VM Value to a SharedValue (owns all data, no GcRefs).
 /// Functions/closures/natives/upvalues/task handles map to Null.
 pub fn value_to_shared(gc: &Gc, val: &Value) -> SharedValue {
-    match val {
-        Value::Int(n) => SharedValue::Int(*n),
-        Value::Float(n) => SharedValue::Float(*n),
-        Value::Bool(b) => SharedValue::Bool(*b),
-        Value::Null => SharedValue::Null,
-        Value::Obj(r) => match gc.get(*r) {
+    match val.classify(gc) {
+        ValueKind::Int(n) => SharedValue::Int(n),
+        ValueKind::Float(n) => SharedValue::Float(n),
+        ValueKind::Bool(b) => SharedValue::Bool(b),
+        ValueKind::Null => SharedValue::Null,
+        ValueKind::Obj(r) => match gc.get(r) {
             Some(obj) => match &obj.kind {
                 ObjKind::String(s) => SharedValue::String(s.clone()),
                 ObjKind::Array(items) => {
@@ -143,65 +144,52 @@ pub enum ValueKind {
     Obj(GcRef),
 }
 
-/// Runtime value. Primitives inline; heap objects via GcRef.
+/// Runtime value. NaN-boxed into 8 bytes.
 #[derive(Clone, Copy)]
-pub enum Value {
-    Int(i64),
-    Float(f64),
-    Bool(bool),
-    Null,
-    Obj(GcRef),
-}
+#[repr(transparent)]
+pub struct Value(pub(crate) NanBoxedValue);
 
 impl Value {
-    // ---- Constructors (method-based API for future NaN-box migration) ----
+    // ---- Constructors ----
 
     /// Create an integer value. For values known to be small, prefer `small_int`.
     /// This allocates a BoxedInt on the GC heap if the value exceeds 48-bit range.
     #[inline]
     pub fn int(n: i64, gc: &mut Gc) -> Value {
-        // 48-bit signed range: -(2^47) to (2^47 - 1)
-        const INT48_MAX: i64 = (1_i64 << 47) - 1;
-        const INT48_MIN: i64 = -(1_i64 << 47);
-        if n >= INT48_MIN && n <= INT48_MAX {
-            Value::Int(n)
-        } else {
-            let r = gc.alloc(ObjKind::BoxedInt(n));
-            Value::Obj(r)
+        match NanBoxedValue::try_from_int(n) {
+            Some(nb) => Value(nb),
+            None => {
+                let r = gc.alloc(ObjKind::BoxedInt(n));
+                Value(NanBoxedValue::from_obj(r))
+            }
         }
     }
 
     /// Create an integer value that is known to fit in 48 bits.
-    /// Panics in debug mode if the value is out of range. Use for literals,
-    /// len, index, bool-to-int, and other known-small values.
+    /// Panics in debug mode if the value is out of range.
     #[inline]
     pub fn small_int(n: i64) -> Value {
-        debug_assert!(
-            n >= -(1_i64 << 47) && n <= (1_i64 << 47) - 1,
-            "BUG: small_int({}) exceeds 48-bit range",
-            n
-        );
-        Value::Int(n)
+        Value(NanBoxedValue::from_small_int(n))
     }
 
     #[inline]
     pub fn float(f: f64) -> Value {
-        Value::Float(f)
+        Value(NanBoxedValue::from_float(f))
     }
 
     #[inline]
     pub fn bool_val(b: bool) -> Value {
-        Value::Bool(b)
+        Value(NanBoxedValue::from_bool(b))
     }
 
     #[inline]
     pub fn null() -> Value {
-        Value::Null
+        Value(NanBoxedValue::null())
     }
 
     #[inline]
     pub fn obj(r: GcRef) -> Value {
-        Value::Obj(r)
+        Value(NanBoxedValue::from_obj(r))
     }
 
     // ---- Extractors (BoxedInt-aware) ----
@@ -209,49 +197,39 @@ impl Value {
     /// Extract an integer, checking both inline Int and heap BoxedInt.
     #[inline]
     pub fn as_int(&self, gc: &Gc) -> Option<i64> {
-        match self {
-            Value::Int(n) => Some(*n),
-            Value::Obj(r) => {
-                if let Some(obj) = gc.get(*r) {
-                    if let ObjKind::BoxedInt(n) = &obj.kind {
-                        return Some(*n);
-                    }
-                }
-                None
-            }
-            _ => None,
+        if let Some(n) = self.0.as_int() {
+            return Some(n);
         }
+        if let Some(r) = self.0.as_obj() {
+            if let Some(obj) = gc.get(r) {
+                if let ObjKind::BoxedInt(n) = &obj.kind {
+                    return Some(*n);
+                }
+            }
+        }
+        None
     }
 
     /// Extract an inline integer only (no GC lookup). Use in hot paths
     /// where BoxedInt is impossible (e.g., loop counters, small constants).
     #[inline]
     pub fn as_inline_int(&self) -> Option<i64> {
-        match self {
-            Value::Int(n) => Some(*n),
-            _ => None,
-        }
+        self.0.as_int()
     }
 
     #[inline]
     pub fn as_float(&self) -> Option<f64> {
-        match self {
-            Value::Float(f) => Some(*f),
-            _ => None,
-        }
+        self.0.as_float()
     }
 
     #[inline]
     pub fn as_bool(&self) -> Option<bool> {
-        match self {
-            Value::Bool(b) => Some(*b),
-            _ => None,
-        }
+        self.0.as_bool()
     }
 
     #[inline]
     pub fn is_null(&self) -> bool {
-        matches!(self, Value::Null)
+        self.0.is_null()
     }
 
     #[inline]
@@ -261,84 +239,54 @@ impl Value {
 
     #[inline]
     pub fn as_obj(&self) -> Option<GcRef> {
-        match self {
-            Value::Obj(r) => Some(*r),
-            _ => None,
-        }
+        self.0.as_obj()
     }
 
     /// Deconstruct into a matchable enum for exhaustive pattern matching.
     /// BoxedInt is transparently unwrapped to `ValueKind::Int`.
     pub fn classify(&self, gc: &Gc) -> ValueKind {
-        match self {
-            Value::Int(n) => ValueKind::Int(*n),
-            Value::Float(f) => ValueKind::Float(*f),
-            Value::Bool(b) => ValueKind::Bool(*b),
-            Value::Null => ValueKind::Null,
-            Value::Obj(r) => {
-                if let Some(obj) = gc.get(*r) {
-                    if let ObjKind::BoxedInt(n) = &obj.kind {
-                        return ValueKind::Int(*n);
-                    }
-                }
-                ValueKind::Obj(*r)
-            }
+        if let Some(n) = self.0.as_int() {
+            return ValueKind::Int(n);
         }
+        if let Some(f) = self.0.as_float() {
+            return ValueKind::Float(f);
+        }
+        if let Some(b) = self.0.as_bool() {
+            return ValueKind::Bool(b);
+        }
+        if self.0.is_null() {
+            return ValueKind::Null;
+        }
+        if let Some(r) = self.0.as_obj() {
+            if let Some(obj) = gc.get(r) {
+                if let ObjKind::BoxedInt(n) = &obj.kind {
+                    return ValueKind::Int(*n);
+                }
+            }
+            return ValueKind::Obj(r);
+        }
+        ValueKind::Null
     }
 
     // ---- Existing methods ----
 
-    pub fn is_truthy(&self, gc: &super::gc::Gc) -> bool {
-        match self {
-            Value::Bool(b) => *b,
-            Value::Int(n) => *n != 0,
-            Value::Float(n) => *n != 0.0,
-            Value::Null => false,
-            Value::Obj(r) => gc.get(*r).is_some_and(|obj| match &obj.kind {
-                ObjKind::String(s) => !s.is_empty(),
-                ObjKind::Array(a) => !a.is_empty(),
-                ObjKind::Object(o) => !o.is_empty(),
-                ObjKind::ResultOk(_) => true,
-                ObjKind::ResultErr(_) => false,
-                ObjKind::BoxedInt(n) => *n != 0,
-                _ => true,
-            }),
-        }
+    pub fn is_truthy(&self, gc: &Gc) -> bool {
+        self.0.is_truthy(gc)
     }
 
-    pub fn type_name(&self, gc: &super::gc::Gc) -> &'static str {
-        match self {
-            Value::Int(_) => "Int",
-            Value::Float(_) => "Float",
-            Value::Bool(_) => "Bool",
-            Value::Null => "Null",
-            Value::Obj(r) => gc.get(*r).map_or("Null", |o| o.type_name()),
-        }
+    pub fn type_name(&self, gc: &Gc) -> &'static str {
+        self.0.type_name(gc)
     }
 
-    pub fn display(&self, gc: &super::gc::Gc) -> String {
-        match self {
-            Value::Int(n) => n.to_string(),
-            Value::Float(n) => format!("{}", n),
-            Value::Bool(b) => b.to_string(),
-            Value::Null => "null".to_string(),
-            Value::Obj(r) => gc.get(*r).map_or("<freed>".to_string(), |o| o.display(gc)),
-        }
+    pub fn display(&self, gc: &Gc) -> String {
+        self.0.display(gc)
     }
 
-    pub fn to_json_string(&self, gc: &super::gc::Gc) -> String {
-        match self {
-            Value::Int(n) => n.to_string(),
-            Value::Float(n) => format!("{}", n),
-            Value::Bool(b) => b.to_string(),
-            Value::Null => "null".to_string(),
-            Value::Obj(r) => gc
-                .get(*r)
-                .map_or("null".to_string(), |o| o.to_json_string(gc)),
-        }
+    pub fn to_json_string(&self, gc: &Gc) -> String {
+        self.0.to_json_string(gc)
     }
 
-    pub fn equals(&self, other: &Value, gc: &super::gc::Gc) -> bool {
+    pub fn equals(&self, other: &Value, gc: &Gc) -> bool {
         // Use classify to handle BoxedInt transparently
         match (self.classify(gc), other.classify(gc)) {
             (ValueKind::Int(a), ValueKind::Int(b)) => a == b,
@@ -363,25 +311,13 @@ impl Value {
     /// Check structural identity for constant dedup (no GC needed).
     #[allow(dead_code)]
     pub fn identical(&self, other: &Value) -> bool {
-        match (self, other) {
-            (Value::Int(a), Value::Int(b)) => a == b,
-            (Value::Float(a), Value::Float(b)) => a == b,
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Null, Value::Null) => true,
-            _ => false,
-        }
+        self.0.identical(&other.0)
     }
 }
 
 impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Value::Int(n) => write!(f, "{}", n),
-            Value::Float(n) => write!(f, "{}", n),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Null => write!(f, "null"),
-            Value::Obj(r) => write!(f, "Obj({})", r.0),
-        }
+        self.0.fmt(f)
     }
 }
 
@@ -398,7 +334,7 @@ impl GcObject {
         }
     }
 
-    pub fn display(&self, gc: &super::gc::Gc) -> String {
+    pub fn display(&self, gc: &Gc) -> String {
         match &self.kind {
             ObjKind::String(s) => s.clone(),
             ObjKind::Array(items) => {
@@ -425,7 +361,7 @@ impl GcObject {
         }
     }
 
-    pub fn to_json_string(&self, gc: &super::gc::Gc) -> String {
+    pub fn to_json_string(&self, gc: &Gc) -> String {
         match &self.kind {
             ObjKind::String(s) => escape_json_string(s),
             ObjKind::Array(items) => {
@@ -463,7 +399,7 @@ impl GcObject {
         }
     }
 
-    pub fn equals(&self, other: &GcObject, gc: &super::gc::Gc) -> bool {
+    pub fn equals(&self, other: &GcObject, gc: &Gc) -> bool {
         match (&self.kind, &other.kind) {
             (ObjKind::String(a), ObjKind::String(b)) => a == b,
             (ObjKind::Array(a), ObjKind::Array(b)) => {
@@ -483,15 +419,15 @@ impl GcObject {
         match &self.kind {
             ObjKind::Array(items) => {
                 for item in items {
-                    if let Value::Obj(r) = item {
-                        worklist.push(*r);
+                    if let Some(r) = item.as_obj() {
+                        worklist.push(r);
                     }
                 }
             }
             ObjKind::Object(map) => {
                 for v in map.values() {
-                    if let Value::Obj(r) = v {
-                        worklist.push(*r);
+                    if let Some(r) = v.as_obj() {
+                        worklist.push(r);
                     }
                 }
             }
@@ -501,13 +437,13 @@ impl GcObject {
                 }
             }
             ObjKind::Upvalue(uv) => {
-                if let Value::Obj(r) = &uv.value {
-                    worklist.push(*r);
+                if let Some(r) = uv.value.as_obj() {
+                    worklist.push(r);
                 }
             }
             ObjKind::ResultOk(v) | ObjKind::ResultErr(v) | ObjKind::Frozen(v) => {
-                if let Value::Obj(r) = v {
-                    worklist.push(*r);
+                if let Some(r) = v.as_obj() {
+                    worklist.push(r);
                 }
             }
             _ => {}
@@ -551,4 +487,14 @@ pub struct ObjUpvalue {
 
 pub struct NativeFn {
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_is_8_bytes() {
+        assert_eq!(std::mem::size_of::<Value>(), 8);
+    }
 }

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -92,18 +92,18 @@ pub fn value_to_shared(gc: &Gc, val: &Value) -> SharedValue {
 /// Convert a SharedValue back to a VM Value (allocates in target GC).
 pub fn shared_to_value(gc: &mut Gc, sv: &SharedValue) -> Value {
     match sv {
-        SharedValue::Int(n) => Value::Int(*n),
-        SharedValue::Float(n) => Value::Float(*n),
-        SharedValue::Bool(b) => Value::Bool(*b),
-        SharedValue::Null => Value::Null,
+        SharedValue::Int(n) => Value::int(*n, gc),
+        SharedValue::Float(n) => Value::float(*n),
+        SharedValue::Bool(b) => Value::bool_val(*b),
+        SharedValue::Null => Value::null(),
         SharedValue::String(s) => {
             let r = gc.alloc(ObjKind::String(s.clone()));
-            Value::Obj(r)
+            Value::obj(r)
         }
         SharedValue::Array(items) => {
             let vals: Vec<Value> = items.iter().map(|sv| shared_to_value(gc, sv)).collect();
             let r = gc.alloc(ObjKind::Array(vals));
-            Value::Obj(r)
+            Value::obj(r)
         }
         SharedValue::Object(map) => {
             let entries: IndexMap<String, Value> = map
@@ -111,21 +111,21 @@ pub fn shared_to_value(gc: &mut Gc, sv: &SharedValue) -> Value {
                 .map(|(k, sv)| (k.clone(), shared_to_value(gc, sv)))
                 .collect();
             let r = gc.alloc(ObjKind::Object(entries));
-            Value::Obj(r)
+            Value::obj(r)
         }
         SharedValue::ResultOk(v) => {
             let inner = shared_to_value(gc, v);
             let r = gc.alloc(ObjKind::ResultOk(inner));
-            Value::Obj(r)
+            Value::obj(r)
         }
         SharedValue::ResultErr(v) => {
             let inner = shared_to_value(gc, v);
             let r = gc.alloc(ObjKind::ResultErr(inner));
-            Value::Obj(r)
+            Value::obj(r)
         }
         SharedValue::Channel(ch) => {
             let r = gc.alloc(ObjKind::Channel(ch.clone()));
-            Value::Obj(r)
+            Value::obj(r)
         }
     }
 }

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -133,6 +133,16 @@ pub fn shared_to_value(gc: &mut Gc, sv: &SharedValue) -> Value {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GcRef(pub usize);
 
+/// Deconstructed value for exhaustive pattern matching.
+/// Use `val.classify(&gc)` to get this from a `Value`.
+pub enum ValueKind {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Null,
+    Obj(GcRef),
+}
+
 /// Runtime value. Primitives inline; heap objects via GcRef.
 #[derive(Clone, Copy)]
 pub enum Value {
@@ -144,6 +154,140 @@ pub enum Value {
 }
 
 impl Value {
+    // ---- Constructors (method-based API for future NaN-box migration) ----
+
+    /// Create an integer value. For values known to be small, prefer `small_int`.
+    /// This allocates a BoxedInt on the GC heap if the value exceeds 48-bit range.
+    #[inline]
+    pub fn int(n: i64, gc: &mut Gc) -> Value {
+        // 48-bit signed range: -(2^47) to (2^47 - 1)
+        const INT48_MAX: i64 = (1_i64 << 47) - 1;
+        const INT48_MIN: i64 = -(1_i64 << 47);
+        if n >= INT48_MIN && n <= INT48_MAX {
+            Value::Int(n)
+        } else {
+            let r = gc.alloc(ObjKind::BoxedInt(n));
+            Value::Obj(r)
+        }
+    }
+
+    /// Create an integer value that is known to fit in 48 bits.
+    /// Panics in debug mode if the value is out of range. Use for literals,
+    /// len, index, bool-to-int, and other known-small values.
+    #[inline]
+    pub fn small_int(n: i64) -> Value {
+        debug_assert!(
+            n >= -(1_i64 << 47) && n <= (1_i64 << 47) - 1,
+            "BUG: small_int({}) exceeds 48-bit range",
+            n
+        );
+        Value::Int(n)
+    }
+
+    #[inline]
+    pub fn float(f: f64) -> Value {
+        Value::Float(f)
+    }
+
+    #[inline]
+    pub fn bool_val(b: bool) -> Value {
+        Value::Bool(b)
+    }
+
+    #[inline]
+    pub fn null() -> Value {
+        Value::Null
+    }
+
+    #[inline]
+    pub fn obj(r: GcRef) -> Value {
+        Value::Obj(r)
+    }
+
+    // ---- Extractors (BoxedInt-aware) ----
+
+    /// Extract an integer, checking both inline Int and heap BoxedInt.
+    #[inline]
+    pub fn as_int(&self, gc: &Gc) -> Option<i64> {
+        match self {
+            Value::Int(n) => Some(*n),
+            Value::Obj(r) => {
+                if let Some(obj) = gc.get(*r) {
+                    if let ObjKind::BoxedInt(n) = &obj.kind {
+                        return Some(*n);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Extract an inline integer only (no GC lookup). Use in hot paths
+    /// where BoxedInt is impossible (e.g., loop counters, small constants).
+    #[inline]
+    pub fn as_inline_int(&self) -> Option<i64> {
+        match self {
+            Value::Int(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_float(&self) -> Option<f64> {
+        match self {
+            Value::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    #[inline]
+    pub fn is_int(&self, gc: &Gc) -> bool {
+        self.as_int(gc).is_some()
+    }
+
+    #[inline]
+    pub fn as_obj(&self) -> Option<GcRef> {
+        match self {
+            Value::Obj(r) => Some(*r),
+            _ => None,
+        }
+    }
+
+    /// Deconstruct into a matchable enum for exhaustive pattern matching.
+    /// BoxedInt is transparently unwrapped to `ValueKind::Int`.
+    pub fn classify(&self, gc: &Gc) -> ValueKind {
+        match self {
+            Value::Int(n) => ValueKind::Int(*n),
+            Value::Float(f) => ValueKind::Float(*f),
+            Value::Bool(b) => ValueKind::Bool(*b),
+            Value::Null => ValueKind::Null,
+            Value::Obj(r) => {
+                if let Some(obj) = gc.get(*r) {
+                    if let ObjKind::BoxedInt(n) = &obj.kind {
+                        return ValueKind::Int(*n);
+                    }
+                }
+                ValueKind::Obj(*r)
+            }
+        }
+    }
+
+    // ---- Existing methods ----
+
     pub fn is_truthy(&self, gc: &super::gc::Gc) -> bool {
         match self {
             Value::Bool(b) => *b,
@@ -156,6 +300,7 @@ impl Value {
                 ObjKind::Object(o) => !o.is_empty(),
                 ObjKind::ResultOk(_) => true,
                 ObjKind::ResultErr(_) => false,
+                ObjKind::BoxedInt(n) => *n != 0,
                 _ => true,
             }),
         }
@@ -194,21 +339,19 @@ impl Value {
     }
 
     pub fn equals(&self, other: &Value, gc: &super::gc::Gc) -> bool {
-        match (self, other) {
-            (Value::Int(a), Value::Int(b)) => a == b,
-            (Value::Float(a), Value::Float(b)) => a == b,
-            (Value::Int(a), Value::Float(b)) => (*a as f64) == *b,
-            (Value::Float(a), Value::Int(b)) => *a == (*b as f64),
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Null, Value::Null) => true,
-            (Value::Obj(a), Value::Obj(b)) => {
-                // Fast path: two live refs with the same arena index are the same
-                // allocation. No ObjKind variant wraps floats (those use Value::Float),
-                // so NaN self-inequality is not a concern.
+        // Use classify to handle BoxedInt transparently
+        match (self.classify(gc), other.classify(gc)) {
+            (ValueKind::Int(a), ValueKind::Int(b)) => a == b,
+            (ValueKind::Float(a), ValueKind::Float(b)) => a == b,
+            (ValueKind::Int(a), ValueKind::Float(b)) => (a as f64) == b,
+            (ValueKind::Float(a), ValueKind::Int(b)) => a == (b as f64),
+            (ValueKind::Bool(a), ValueKind::Bool(b)) => a == b,
+            (ValueKind::Null, ValueKind::Null) => true,
+            (ValueKind::Obj(a), ValueKind::Obj(b)) => {
                 if a == b {
                     return true;
                 }
-                match (gc.get(*a), gc.get(*b)) {
+                match (gc.get(a), gc.get(b)) {
                     (Some(oa), Some(ob)) => oa.equals(ob, gc),
                     _ => false,
                 }


### PR DESCRIPTION
## Summary

- Migrates the VM `Value` type from a 16-byte enum to an 8-byte NaN-boxed newtype (`struct Value(NanBoxedValue)`), halving memory usage for all registers, arrays, and object maps
- Adds a method-based API with BoxedInt-aware extractors: `as_int(&gc)` transparently handles both inline 48-bit ints and heap-allocated large integers
- Implements three-tier arithmetic overflow: inline int → BoxedInt (heap) → float promotion
- Updates all 661 constructor sites and 246 pattern match sites across machine.rs (2495 lines), builtins.rs (3516 lines), and 6 other VM files

## Roadmap Item

`- [ ] NaN-boxed value representation (uniform 64-bit)` (Milestone 2 Deliverables)

## Test plan

- [x] All 1186 Rust tests pass (`cargo test`)
- [x] `size_of::<Value>() == 8` assertion test added
- [x] `forge run examples/hello.fg` runs correctly
- [x] `forge run examples/functional.fg` runs correctly
- [x] Parity tests pass (interpreter/VM/JIT cross-backend)
- [x] JIT fib(30) test passes
- [ ] Manual: run `forge test` for Forge-level integration tests