### PR TITLE
feat(jit): enable tiered compilation by default

### DIFF
--- a/.planning/tiered-compilation.plan.md
+++ b/.planning/tiered-compilation.plan.md
@@ -1,0 +1,76 @@
+# Plan: Tiered compilation (interpret → profile → JIT)
+
+## Goal
+
+Enable automatic tiered compilation: functions start interpreted, get profiled for hotness, and are JIT-compiled when hot — all without user flags.
+
+## Current State
+
+- Profiler exists with `is_hot()` (HOT_THRESHOLD = 100 calls), timing, reporting
+- Auto-JIT code exists in Call handler: checks `profiler.is_hot()`, compiles, caches
+- JIT dispatch code exists: routes cached functions to native code
+- **Problem:** Profiler is disabled by default (`VM::new()` → `Profiler::new(false)`). Auto-JIT never triggers in normal `--vm` mode.
+- `--profile` flag enables profiler + timing overhead, but that's for user-facing reports, not auto-JIT
+
+## Approach
+
+### Option A: Always enable the full profiler
+
+Simple but wasteful — `enter_function` does string allocation + HashMap lookup + Instant::now() on every call even when not `--profile`.
+
+### Option B: Lightweight call counter separate from profiler (CHOSEN)
+
+Add a simple `HashMap<String, u32>` call counter that's always active when `jit` feature is enabled. No timing overhead. The full profiler stays disabled by default for `--profile` reporting.
+
+Actually, even simpler: just change `profiler.enter_function()` to skip timing when not in profile mode but still count calls. The profiler already guards timing with `if !self.enabled { return; }`. We can split this: always count calls (when jit feature), but only track timing when enabled.
+
+### Simplest correct approach
+
+1. Add `jit_counting: bool` to Profiler — when true, count calls even when profiler timing is disabled
+2. `VM::new()` sets `jit_counting = cfg!(feature = "jit")`
+3. `enter_function()` increments call count if `jit_counting || enabled`, but only pushes timing if `enabled`
+4. `is_hot()` works regardless of `enabled` (it just reads the counter)
+
+Actually even simpler: the profiler's `enter_function` does 3 things: (1) increment counter, (2) push call stack for timing. We can separate these. But the cleanest approach is:
+
+**Just enable counting unconditionally in enter_function. Guard only the timing push.**
+
+This means `enter_function` always counts, but the Instant::now() + call_stack push only happens when `enabled`. The HashMap lookup for incrementing is cheap.
+
+## Changes
+
+### `src/vm/profiler.rs`
+
+- `enter_function`: Always increment call count. Only push to call_stack when `enabled`.
+- `exit_function`: Unchanged (already guards on `enabled`).
+
+### `src/vm/machine.rs`
+
+- No changes needed — `profiler.enter_function()` is already called unconditionally for named functions in the Call handler.
+
+Wait, let me verify... Actually `enter_function` returns early when `!self.enabled`. Let me re-check.
+
+Looking at the code: `enter_function` does `if !self.enabled { return; }` at line 43. So when profiler is disabled, NO counting happens. I need to change this.
+
+### Actual changes:
+
+1. **`src/vm/profiler.rs`**: Remove the early return from `enter_function` when disabled. Instead, always count calls, but only track timing when enabled.
+
+2. That's it. The auto-JIT path already checks `profiler.is_hot()` which reads call_count. Once counting works, auto-JIT triggers automatically.
+
+## Edge Cases
+
+- `exit_function()` also early-returns when disabled. That's fine — we're not pushing to call_stack when disabled, so there's nothing to pop.
+- `enter_function` allocates a String for the HashMap key on every call. This is the main overhead. For hot functions, the key already exists (just incrementing), so the allocation is wasted. Could use `entry()` API which avoids allocation when key exists... but it already uses `entry()` which requires an owned String. Acceptable overhead.
+- String allocation per call is the real cost. Could optimize later with interned keys, but for now it's fine — it's a HashMap lookup + u32 increment, no timing.
+
+## Test Strategy
+
+- Existing profiler tests should still pass (they use `Profiler::new(true)`)
+- Add test: `Profiler::new(false)` still counts calls and `is_hot()` works
+- Existing JIT tests exercise auto-JIT indirectly (run_jit_function calls execute which triggers Call)
+- Integration test: a function called 100+ times gets JIT-compiled automatically
+
+## Rollback
+
+Revert the `enter_function` change — put back the early return.

--- a/src/vm/jit_tests.rs
+++ b/src/vm/jit_tests.rs
@@ -650,3 +650,35 @@ fn jit_global_read() {
     let out = run_jit_function("let x = 10\nfn get_x() { return x }\nprintln(get_x())");
     assert_eq!(out, vec!["10"]);
 }
+
+#[test]
+fn jit_auto_tiered_compilation() {
+    // Verify that VM::new() (profiler disabled) auto-JIT compiles hot functions.
+    // A function called 101 times should be JIT-compiled and produce correct results.
+    let source = r#"
+fn add(a, b) { return a + b }
+let mut total = 0
+let mut i = 0
+while i < 101 {
+    total = total + add(i, 1)
+    i = i + 1
+}
+println(total)
+"#;
+    let mut lexer = crate::lexer::Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = crate::parser::Parser::new(tokens);
+    let program = parser.parse_program().unwrap();
+    let chunk = crate::vm::compiler::compile(&program).unwrap();
+
+    let mut vm = VM::new();
+    vm.execute(&chunk).unwrap();
+
+    // After 101 calls, add() should be in the JIT cache
+    assert!(
+        vm.jit_cache.contains_key("add"),
+        "Expected 'add' to be auto-JIT compiled after 101 calls"
+    );
+    // sum of (i+1) for i in 0..101 = sum of 1..102 = 101*102/2 = 5151
+    assert_eq!(vm.output, vec!["5151"]);
+}

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -2105,15 +2105,22 @@ impl VM {
                         let chunk = closure.function.chunk.clone();
                         let func_name = closure.function.name.clone();
 
-                        if !func_name.is_empty() {
+                        // Count calls for profiling and JIT hotness detection.
+                        // Skip for functions already JIT-compiled to avoid
+                        // per-call string allocation overhead on hot paths.
+                        #[cfg(feature = "jit")]
+                        let already_jit =
+                            !func_name.is_empty() && self.jit_cache.contains_key(&func_name);
+                        #[cfg(not(feature = "jit"))]
+                        let already_jit = false;
+
+                        if !func_name.is_empty() && !already_jit {
                             self.profiler.enter_function(&func_name);
                         }
 
                         // Auto-JIT: compile hot functions on the fly
                         #[cfg(feature = "jit")]
-                        if !func_name.is_empty()
-                            && !self.jit_cache.contains_key(&func_name)
-                            && self.profiler.is_hot(&func_name)
+                        if !func_name.is_empty() && !already_jit && self.profiler.is_hot(&func_name)
                         {
                             let type_info = super::jit::type_analysis::analyze(&chunk);
                             let needs_vm_ptr = type_info.has_string_ops

--- a/src/vm/profiler.rs
+++ b/src/vm/profiler.rs
@@ -38,16 +38,21 @@ impl Profiler {
         self.enabled
     }
 
+    /// Record a function call. Always increments the call counter (for JIT
+    /// hotness detection). Only tracks timing when the profiler is fully
+    /// enabled (`--profile`).
+    ///
+    /// Note: `exit_function` still early-returns when disabled because there
+    /// is no timing data to record (we don't push to `call_stack`).
     pub fn enter_function(&mut self, name: &str) {
-        if !self.enabled {
-            return;
-        }
         let entry = self
             .stats
             .entry(name.to_string())
             .or_insert_with(FunctionStats::new);
         entry.call_count = entry.call_count.saturating_add(1);
-        self.call_stack.push((name.to_string(), Instant::now()));
+        if self.enabled {
+            self.call_stack.push((name.to_string(), Instant::now()));
+        }
     }
 
     pub fn exit_function(&mut self) {
@@ -139,12 +144,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn profiler_disabled_does_nothing() {
+    fn profiler_disabled_still_counts_calls() {
         let mut p = Profiler::new(false);
         p.enter_function("foo");
         p.exit_function();
-        assert_eq!(p.call_count("foo"), 0);
+        // Call counting always works (for JIT hotness detection).
+        // Only timing is disabled.
+        assert_eq!(p.call_count("foo"), 1);
         assert!(!p.is_hot("foo"));
+        let stats = p.stats.get("foo").unwrap();
+        assert_eq!(stats.total_time, std::time::Duration::ZERO);
     }
 
     #[test]
@@ -231,5 +240,17 @@ mod tests {
         p.enter_function("overflow");
         p.exit_function();
         assert_eq!(p.call_count("overflow"), u32::MAX);
+    }
+
+    #[test]
+    fn profiler_disabled_detects_hot() {
+        let mut p = Profiler::new(false);
+        for _ in 0..100 {
+            p.enter_function("hot_fn");
+        }
+        assert!(p.is_hot("hot_fn"));
+        // No timing recorded when disabled
+        let stats = p.stats.get("hot_fn").unwrap();
+        assert_eq!(stats.total_time, Duration::ZERO);
     }
 }


### PR DESCRIPTION
## Summary

- Enable automatic tiered compilation: functions start interpreted, get profiled, and are JIT-compiled when hot (100+ calls)
- Profiler now always counts function calls regardless of `--profile` flag; only timing is gated
- Skip profiler counting for already-JIT-compiled functions to avoid per-call overhead
- No user flags needed — tiered compilation is automatic when the `jit` feature is active

Roadmap item: **Tiered compilation: interpret -> profile -> JIT** (Phase 2.4)

## How it works

1. Every function call increments a counter in the profiler (cheap HashMap increment)
2. When a function reaches 100 calls, `is_hot()` returns true
3. The auto-JIT block compiles the function to native code via Cranelift
4. Subsequent calls dispatch to native code, skipping both profiling and interpretation

## Test plan

- [x] All 1198 tests pass (`cargo test --features jit`)
- [x] New test: `jit_auto_tiered_compilation` verifies auto-JIT triggers on VM::new()
- [x] New test: `profiler_disabled_still_counts_calls` verifies counting without timing
- [x] New test: `profiler_disabled_detects_hot` verifies hotness detection without --profile
- [x] Examples run correctly (hello.fg, functional.fg)