### PR TITLE
feat: standalone AOT binaries via libforge static library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ categories = ["compilers", "command-line-utilities"]
 readme = "README.md"
 exclude = ["docs/book/programming-forge.pdf", "docs/cover.jpeg", "docs/spec/**", "docs/PROGRAMMING_FORGE.md", "docs/part*.md", "benchmarks/**", "spec/**"]
 
+[lib]
+name = "forge_lang"
+path = "src/lib.rs"
+crate-type = ["rlib", "staticlib"]
+
 [[bin]]
 name = "forge"
 path = "src/main.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,62 @@
+// Forge language library — exposes the runtime for AOT-compiled binaries.
+//
+// AOT binaries link against libforge.a and call forge_execute_bytecode()
+// to run embedded bytecode without needing the `forge` CLI.
+
+mod errors;
+mod interpreter;
+mod lexer;
+mod manifest;
+mod package;
+mod parser;
+mod permissions;
+mod registry;
+mod runtime;
+mod stdlib;
+mod typechecker;
+pub mod vm;
+
+use std::panic;
+
+/// Execute serialized bytecode. Returns 0 on success, 1 on error.
+///
+/// # Safety
+/// `bytecode_ptr` must point to `bytecode_len` valid bytes of serialized
+/// Forge bytecode (produced by `vm::serialize::serialize_chunk`).
+#[no_mangle]
+pub extern "C" fn forge_execute_bytecode(bytecode_ptr: *const u8, bytecode_len: usize) -> i32 {
+    if bytecode_ptr.is_null() || bytecode_len == 0 {
+        eprintln!("forge: null or empty bytecode");
+        return 1;
+    }
+
+    let bytecode = unsafe { std::slice::from_raw_parts(bytecode_ptr, bytecode_len) };
+
+    // Catch panics so we don't abort the process
+    let result = panic::catch_unwind(|| {
+        let chunk = match vm::serialize::deserialize_chunk(bytecode) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("forge: bytecode deserialization failed: {}", e.message);
+                return 1;
+            }
+        };
+
+        let mut machine = vm::machine::VM::new();
+        match machine.execute(&chunk) {
+            Ok(_) => 0,
+            Err(e) => {
+                eprintln!("forge: runtime error: {}", e);
+                1
+            }
+        }
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(_) => {
+            eprintln!("forge: internal panic during execution");
+            1
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1010,11 +1010,18 @@ fn compile_to_native_aot(source: &str, filename: &str, file_path: &PathBuf, stri
 
     match native::build_native_aot(&bytecode, file_path) {
         Ok(output_path) => {
+            let standalone = native::find_libforge_dir().is_some();
+            let runtime_msg = if standalone {
+                "standalone (libforge linked)"
+            } else {
+                "Forge VM required at execution time"
+            };
             println!(
-                "Built AOT binary {} -> {}\n  bytecode embedded ({} bytes, no source exposure)\n  runtime: Forge VM required at execution time",
+                "Built AOT binary {} -> {}\n  bytecode embedded ({} bytes, no source exposure)\n  runtime: {}",
                 filename,
                 output_path.display(),
-                bytecode.len()
+                bytecode.len(),
+                runtime_msg
             );
         }
         Err(message) => {

--- a/src/native.rs
+++ b/src/native.rs
@@ -104,9 +104,10 @@ int main(void) {{
         cmd.arg("-ldl");
     }
 
-    let status = cmd
-        .status()
-        .map_err(|e| format!("failed to invoke C compiler for standalone AOT: {e}"))?;
+    let status = cmd.status().map_err(|e| {
+        let _ = fs::remove_file(&c_path);
+        format!("failed to invoke C compiler for standalone AOT: {e}")
+    })?;
     let _ = fs::remove_file(&c_path);
 
     if !status.success() {

--- a/src/native.rs
+++ b/src/native.rs
@@ -10,8 +10,122 @@ pub fn build_native_launcher(source: &str, source_path: &Path) -> Result<PathBuf
 }
 
 pub fn build_native_aot(bytecode: &[u8], source_path: &Path) -> Result<PathBuf, String> {
+    // Try standalone build first (links against libforge.a — no forge needed at runtime)
+    if let Some(lib_dir) = find_libforge_dir() {
+        return build_standalone_aot(bytecode, source_path, &lib_dir);
+    }
+    // Fall back to launcher mode (requires forge at runtime)
     let c_source_fn = |forge_bin: &str| aot_launcher_c_source(bytecode, forge_bin);
     compile_launcher(source_path, "aot", c_source_fn)
+}
+
+/// Find the directory containing libforge_lang.a
+pub fn find_libforge_dir() -> Option<PathBuf> {
+    // Check FORGE_LIB_DIR env var first
+    if let Ok(dir) = env::var("FORGE_LIB_DIR") {
+        let path = PathBuf::from(&dir).join("libforge_lang.a");
+        if path.exists() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    // Check next to the forge binary
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let path = dir.join("libforge_lang.a");
+            if path.exists() {
+                return Some(dir.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+/// Build a standalone AOT binary that links against libforge.a
+#[cfg(unix)]
+fn build_standalone_aot(
+    bytecode: &[u8],
+    source_path: &Path,
+    lib_dir: &Path,
+) -> Result<PathBuf, String> {
+    let output_path = native_output_path(source_path);
+    let byte_list = bytecode
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let c_source = format!(
+        r#"#include <stddef.h>
+#include <stdint.h>
+
+extern int32_t forge_execute_bytecode(const uint8_t *bytecode, size_t len);
+
+static const unsigned char FORGE_BYTECODE[] = {{ {byte_list} }};
+static const size_t FORGE_BYTECODE_LEN = sizeof(FORGE_BYTECODE);
+
+int main(void) {{
+    return (int)forge_execute_bytecode(FORGE_BYTECODE, FORGE_BYTECODE_LEN);
+}}
+"#,
+        byte_list = byte_list,
+    );
+
+    let build_id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("failed to create timestamp: {e}"))?
+        .as_nanos();
+    let c_path = env::temp_dir().join(format!("forge-aot-{}-{}.c", std::process::id(), build_id));
+    fs::write(&c_path, c_source).map_err(|e| format!("failed to write AOT source: {e}"))?;
+
+    let mut cmd = Command::new("cc");
+    cmd.arg("-O2")
+        .arg(&c_path)
+        .arg("-o")
+        .arg(&output_path)
+        .arg(format!("-L{}", lib_dir.display()))
+        .arg("-lforge_lang")
+        .arg("-lm")
+        .arg("-lpthread")
+        .arg("-lresolv");
+
+    // macOS requires additional frameworks for system dependencies
+    #[cfg(target_os = "macos")]
+    {
+        cmd.arg("-framework").arg("CoreFoundation");
+        cmd.arg("-framework").arg("Security");
+        cmd.arg("-framework").arg("SystemConfiguration");
+        cmd.arg("-framework").arg("IOKit");
+        cmd.arg("-liconv");
+    }
+
+    // Linux requires libdl
+    #[cfg(target_os = "linux")]
+    {
+        cmd.arg("-ldl");
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("failed to invoke C compiler for standalone AOT: {e}"))?;
+    let _ = fs::remove_file(&c_path);
+
+    if !status.success() {
+        return Err(format!(
+            "standalone AOT compilation failed for '{}' (try without FORGE_LIB_DIR for launcher mode)",
+            output_path.display()
+        ));
+    }
+
+    Ok(output_path)
+}
+
+#[cfg(not(unix))]
+fn build_standalone_aot(
+    _bytecode: &[u8],
+    _source_path: &Path,
+    _lib_dir: &Path,
+) -> Result<PathBuf, String> {
+    Err("standalone AOT is currently supported on Unix-like systems only".to_string())
 }
 
 fn compile_launcher<F>(source_path: &Path, mode: &str, make_c_source: F) -> Result<PathBuf, String>


### PR DESCRIPTION
## Summary

- Add `[lib]` target to Cargo.toml producing `libforge_lang.a` (staticlib + rlib)
- Create `src/lib.rs` with `forge_execute_bytecode()` extern C entry point
- `forge build --aot` now produces **standalone** binaries when `libforge_lang.a` is available
- Falls back to launcher mode (requires `forge` at runtime) when library not found
- Binary catches panics via `catch_unwind()` and reports errors to stderr

### How it works

1. `cargo build` produces both `forge` binary and `libforge_lang.a`
2. `FORGE_LIB_DIR=/path/to/lib forge build --aot app.fg` creates a standalone binary
3. The binary embeds serialized bytecode and links against `libforge_lang.a`
4. No `forge` CLI needed at runtime — the binary is self-contained

### Binary sizes (release)

- `libforge_lang.a`: ~148MB (includes all deps statically)
- Standalone hello-world binary: ~29MB

Closes roadmap item: `forge build --native app.fg → app` (standalone binary)

## Test plan

- [x] All 1215 tests pass (`cargo test --all-targets`)
- [x] Examples run correctly
- [x] Standalone AOT binary runs without `forge` on PATH
- [x] Fallback launcher mode still works when `libforge_lang.a` not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)