### PR TITLE
fix(vm): include columns in runtime error traces

### DIFF
--- a/.planning/vm-honesty-source-spans.plan.md
+++ b/.planning/vm-honesty-source-spans.plan.md
@@ -1,0 +1,75 @@
+# VM Honesty + Source Spans Plan
+
+## Goal
+
+Finish the still-relevant parts of `PRODUCTION_READINESS.md` Group E:
+
+- Stop silently accepting VM-only-unsupported standalone decorators when the compiler is called directly.
+- Extend VM runtime error traces from line-only frames to line + column frames.
+
+## Current State
+
+Some E1 bullets are stale:
+
+- `schedule`, `watch`, `spawn`, `ask`, `await`, `must`, and `freeze` now have VM opcodes and runtime implementations.
+- The CLI already preflights decorator-driven runtime features and rejects `@server` / route decorators before VM execution.
+- The compiler still has `Stmt::DecoratorStmt(_) => Ok(())`, which is unsafe if tests or embedders call `vm::compiler::compile` directly.
+
+E2 is partially done:
+
+- `Chunk.lines` records per-op source lines.
+- `VMError` collects stack frames and `Display` renders `at <fn> (line N)`.
+- `SpannedStmt` already has `col`, but the compiler drops it before bytecode emission.
+
+## Implementation
+
+1. Add column metadata beside existing line metadata.
+   - Add `cols: Vec<usize>` to `Chunk`.
+   - Add `Chunk::emit_at(instruction, line, col)` and keep `Chunk::emit(instruction, line)` only as a compatibility wrapper for hand-built test chunks, where it pushes `col = 0`.
+   - Add a debug invariant after emission that `code.len() == lines.len() == cols.len()`.
+   - Update bytecode serialization because line tables are serialized today:
+     - Bump `VERSION_MINOR` from `1` to `2`.
+     - Write a column table immediately after the existing line table.
+     - Pass root bytecode version into recursive `read_chunk_inner`.
+     - For old `1.1` bytecode, synthesize `cols = vec![0; code.len()]`.
+     - For `1.2+`, read the column table, cap it like the line table, and reject malformed chunks where `lines.len()` or `cols.len()` does not match `code.len()`.
+
+2. Track the current source span in the compiler.
+   - Add `current_col` next to `current_line`.
+   - Add a small `set_current_span(line, col)` helper plus a `set_span(&SpannedStmt)` convenience helper.
+   - Replace every `current_line = s.line` / `current_line = spanned.line` assignment with the helper. A mechanical grep for `current_line = .*\\.line` must come back empty.
+   - Update every child-compiler initialization that copies `current_line = c.current_line` to also copy `current_col = c.current_col`.
+   - Update `Compiler::emit` to call `Chunk::emit_at(inst, actual_line, actual_col)`, where `actual_col` falls back to `current_col` exactly as line falls back to `current_line`.
+   - Cover `compile_spawn_body`, `compile()` / `compile_module()` / REPL compile loops, `FnDef`, `ScheduleBlock`, `WatchBlock`, statement `Spawn`, expression `Spawn`, lambda, block, match/when arms, try/catch, safe/timeout/retry, loops, and squad.
+
+3. Render columns in VM stack traces.
+   - Add `col: usize` to `StackFrame`.
+   - Update `collect_stack_trace` to read `chunk.cols[ip - 1]` with the same bounds guard used for `chunk.lines`.
+   - Render frames as `at <function> (line N, col M)` when `col > 0`; keep `line N` fallback for old/deserialized hand-built chunks with no column.
+
+4. Make standalone decorators fail honestly in direct VM compilation.
+   - Replace `Stmt::DecoratorStmt(_) => Ok(())` with a `CompileError` saying VM does not support standalone decorator-driven runtime features and to use the interpreter.
+   - Do not reject decorators attached to `FnDef`: metadata decorators like `@test`, `@skip`, `@before`, and `@after` remain supported by existing compiler paths.
+
+## Tests
+
+- Add/adjust VM tests:
+  - Existing VM error display test should assert the rendered trace includes `col`.
+  - Add a compile test for standalone decorator rejection (`@server(...)` or `@unknown`) through `compiler::compile`, not only CLI preflight.
+  - Add a compile test proving metadata decorators on functions (`@test fn ...`) still compile.
+  - Add a nested function or lambda error test proving child compiler chunks preserve `col > 0`.
+- Add/adjust serialization tests:
+  - Round-trip a hand-built chunk and assert `cols` round trips.
+  - Round-trip a compiled program and assert `cols` round trips.
+  - Add a v1.1 compatibility fixture/byte stream with no column table and assert `cols` is synthesized as zeros.
+- Run:
+  - `cargo test vm_error_stack_trace --lib`
+  - `cargo test serialize --lib`
+  - `cargo test parity_corpus_ --lib`
+  - `cargo test vm::compiler --lib` or the focused compiler test filter
+  - `cargo test`
+
+## Risks
+
+- Bytecode serialization currently writes line tables. Adding columns without a version bump or backward-compatible decoder would corrupt `.fgc` compatibility.
+- Many compiler call sites pass `0` for line; the fallback behavior must remain unchanged for line while adding equivalent column fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **VM error traces now include columns when available** — bytecode chunks carry source columns alongside line tables, old v1.1 bytecode still deserializes with zero columns, and standalone decorator statements now fail VM compilation instead of being silently ignored.
 - **OpenTelemetry feature path is now CI-tested and cheaper when inactive** — CI builds `--features otel`, the OTel export path has a smoke test, and request-span traceparent extraction is skipped unless OTel export was activated at runtime.
 - **Empty request IDs no longer produce blank span fields** — inbound `X-Request-Id: ` now records as `"unknown"` with a warning, and request-id extraction is covered for empty, non-ASCII, and oversized header values.
 

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -165,6 +165,7 @@ pub struct Chunk {
     pub code: Vec<u32>,
     pub constants: Vec<Constant>,
     pub lines: Vec<usize>,
+    pub cols: Vec<usize>,
     pub name: String,
     pub prototypes: Vec<Chunk>,
     pub max_registers: u8,
@@ -179,6 +180,7 @@ impl Chunk {
             code: Vec::new(),
             constants: Vec::new(),
             lines: Vec::new(),
+            cols: Vec::new(),
             name: name.to_string(),
             prototypes: Vec::new(),
             max_registers: 0,
@@ -188,9 +190,19 @@ impl Chunk {
         }
     }
 
+    /// Emit with column 0. Kept for hand-built test chunks and compatibility
+    /// with callers that do not have parser span metadata.
+    #[allow(dead_code)]
     pub fn emit(&mut self, instruction: u32, line: usize) {
+        self.emit_at(instruction, line, 0);
+    }
+
+    pub fn emit_at(&mut self, instruction: u32, line: usize, col: usize) {
         self.code.push(instruction);
         self.lines.push(line);
+        self.cols.push(col);
+        debug_assert_eq!(self.code.len(), self.lines.len());
+        debug_assert_eq!(self.code.len(), self.cols.len());
     }
 
     pub fn add_constant(&mut self, value: Constant) -> u16 {

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -43,9 +43,10 @@ pub struct Compiler {
     parent_upvalues: Vec<(String, u8)>,
     module_mode: bool,
     /// Source line currently being compiled. Top-level loops update this
-    /// from `SpannedStmt::line` before each statement so any `emit` that
-    /// passes `0` for the line picks up a real number instead.
+    /// from `SpannedStmt` before each statement so any `emit` that passes
+    /// `0` for the line picks up a real source span instead.
     current_line: usize,
+    current_col: usize,
 }
 
 #[derive(Debug)]
@@ -76,6 +77,7 @@ impl Compiler {
             parent_upvalues: Vec::new(),
             module_mode: false,
             current_line: 0,
+            current_col: 0,
         }
     }
 
@@ -117,8 +119,18 @@ impl Compiler {
         // never got plumbed through. Fall back to `current_line`, which is
         // updated per top-level statement, so runtime stack traces at least
         // point at the right statement instead of always reporting line 0.
-        let actual = if line == 0 { self.current_line } else { line };
-        self.chunk.emit(inst, actual);
+        let actual_line = if line == 0 { self.current_line } else { line };
+        let actual_col = self.current_col;
+        self.chunk.emit_at(inst, actual_line, actual_col);
+    }
+
+    fn set_current_span(&mut self, line: usize, col: usize) {
+        self.current_line = line;
+        self.current_col = col;
+    }
+
+    fn set_span(&mut self, spanned: &SpannedStmt) {
+        self.set_current_span(spanned.line, spanned.col);
     }
 
     fn emit_jump(&mut self, op: OpCode, a: u8, line: usize) -> usize {
@@ -246,7 +258,7 @@ pub fn compile(program: &Program) -> Result<Chunk, CompileError> {
     let mut c = Compiler::new("<main>");
     c.begin_scope();
     for spanned in &program.statements {
-        c.current_line = spanned.line;
+        c.set_span(spanned);
         compile_stmt(&mut c, &spanned.stmt)?;
     }
     c.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -259,7 +271,7 @@ pub fn compile_module(program: &Program) -> Result<Chunk, CompileError> {
     c.module_mode = true;
     c.begin_scope();
     for spanned in &program.statements {
-        c.current_line = spanned.line;
+        c.set_span(spanned);
         compile_stmt(&mut c, &spanned.stmt)?;
     }
     c.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -275,7 +287,7 @@ pub fn compile_repl(program: &Program) -> Result<Chunk, CompileError> {
     let mut has_result = false;
 
     for spanned in &program.statements {
-        c.current_line = spanned.line;
+        c.set_span(spanned);
         match &spanned.stmt {
             Stmt::Expression(expr) if !is_output_expr(expr) => {
                 compile_expr(&mut c, expr, result_reg)?;
@@ -553,11 +565,11 @@ fn compile_spawn_body(sc: &mut Compiler, body: &[SpannedStmt]) -> Result<(), Com
     }
     let (init, last) = body.split_at(body.len() - 1);
     for s in init {
-        sc.current_line = s.line;
+        sc.set_span(s);
         compile_stmt(sc, &s.stmt)?;
     }
     let last_stmt = &last[0];
-    sc.current_line = last_stmt.line;
+    sc.set_span(last_stmt);
     match &last_stmt.stmt {
         Stmt::Expression(expr) => {
             let dst = sc.alloc_reg()?;
@@ -678,12 +690,13 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             fc.parent_locals = parent_locals;
             fc.parent_upvalues = parent_upvalues;
             fc.current_line = c.current_line;
+            fc.current_col = c.current_col;
             fc.begin_scope();
             for param in params {
                 fc.add_local(&param.name, true)?;
             }
             for s in body {
-                fc.current_line = s.line;
+                fc.set_span(s);
                 compile_stmt(&mut fc, &s.stmt)?;
             }
             fc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -733,7 +746,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in then_body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -743,7 +756,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                 c.patch_jump(else_jump);
                 c.begin_scope();
                 for s in eb {
-                    c.current_line = s.line;
+                    c.set_span(s);
                     compile_stmt(c, &s.stmt)?;
                 }
                 c.end_scope();
@@ -769,7 +782,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -796,7 +809,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -870,7 +883,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             }
 
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -924,7 +937,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                     Pattern::Wildcard => {
                         c.begin_scope();
                         for s in &arm.body {
-                            c.current_line = s.line;
+                            c.set_span(s);
                             compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
@@ -952,7 +965,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                         let vr = c.add_local(name, false)?;
                         c.emit(encode_abc(OpCode::Move, vr, subj, 0), 0);
                         for s in &arm.body {
-                            c.current_line = s.line;
+                            c.set_span(s);
                             compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
@@ -971,7 +984,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
                         c.begin_scope();
                         for s in &arm.body {
-                            c.current_line = s.line;
+                            c.set_span(s);
                             compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
@@ -1000,7 +1013,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                             }
                         }
                         for s in &arm.body {
-                            c.current_line = s.line;
+                            c.set_span(s);
                             compile_stmt(c, &s.stmt)?;
                         }
                         c.end_scope();
@@ -1067,7 +1080,10 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             )
         }
 
-        Stmt::DecoratorStmt(_) => Ok(()),
+        Stmt::DecoratorStmt(decorator) => Err(CompileError::new(&format!(
+            "VM does not support standalone decorator '@{}' — use --interpreter for decorator-driven runtime features",
+            decorator.name
+        ))),
 
         Stmt::StructDef { name, fields, .. } => compile_hidden_stmt(
             c,
@@ -1266,7 +1282,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1298,7 +1314,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
 
             c.begin_scope();
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1352,7 +1368,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1418,9 +1434,10 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             sc.parent_locals = parent_locals;
             sc.parent_upvalues = parent_upvalues;
             sc.current_line = c.current_line;
+            sc.current_col = c.current_col;
             sc.begin_scope();
             for s in body {
-                sc.current_line = s.line;
+                sc.set_span(s);
                 compile_stmt(&mut sc, &s.stmt)?;
             }
             sc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -1457,9 +1474,10 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             sc.parent_locals = parent_locals;
             sc.parent_upvalues = parent_upvalues;
             sc.current_line = c.current_line;
+            sc.current_col = c.current_col;
             sc.begin_scope();
             for s in body {
-                sc.current_line = s.line;
+                sc.set_span(s);
                 compile_stmt(&mut sc, &s.stmt)?;
             }
             sc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -1550,7 +1568,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             });
             c.begin_scope();
             for s in try_body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1567,7 +1585,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
                 mutable: false,
             });
             for s in catch_body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1634,6 +1652,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             sc.parent_locals = parent_locals;
             sc.parent_upvalues = parent_upvalues;
             sc.current_line = c.current_line;
+            sc.current_col = c.current_col;
             sc.begin_scope();
             compile_spawn_body(&mut sc, body)?;
             sc.chunk.upvalue_count = sc.upvalues.len() as u8;
@@ -1655,7 +1674,7 @@ fn compile_stmt(c: &mut Compiler, stmt: &Stmt) -> Result<(), CompileError> {
             let dst = c.alloc_reg()?;
             c.emit(encode_abc(OpCode::SquadBegin, dst, 0, 0), c.current_line);
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.emit(encode_abc(OpCode::SquadEnd, dst, 0, 0), c.current_line);
@@ -1867,12 +1886,13 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
             lc.parent_locals = parent_locals;
             lc.parent_upvalues = parent_upvalues;
             lc.current_line = c.current_line;
+            lc.current_col = c.current_col;
             lc.begin_scope();
             for p in params {
                 lc.add_local(&p.name, true)?;
             }
             for s in body {
-                lc.current_line = s.line;
+                lc.set_span(s);
                 compile_stmt(&mut lc, &s.stmt)?;
             }
             lc.emit(encode_abc(OpCode::ReturnNull, 0, 0, 0), 0);
@@ -1900,7 +1920,7 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
         Expr::Block(stmts) => {
             c.begin_scope();
             for s in stmts {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.end_scope();
@@ -1937,6 +1957,7 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
             sc.parent_locals = parent_locals;
             sc.parent_upvalues = parent_upvalues;
             sc.current_line = c.current_line;
+            sc.current_col = c.current_col;
             sc.begin_scope();
             compile_spawn_body(&mut sc, body)?;
             sc.chunk.upvalue_count = sc.upvalues.len() as u8;
@@ -1953,7 +1974,7 @@ fn compile_expr(c: &mut Compiler, expr: &Expr, dst: u8) -> Result<(), CompileErr
         Expr::Squad(body) => {
             c.emit(encode_abc(OpCode::SquadBegin, dst, 0, 0), c.current_line);
             for s in body {
-                c.current_line = s.line;
+                c.set_span(s);
                 compile_stmt(c, &s.stmt)?;
             }
             c.emit(encode_abc(OpCode::SquadEnd, dst, 0, 0), c.current_line);

--- a/src/vm/jit_tests.rs
+++ b/src/vm/jit_tests.rs
@@ -453,6 +453,16 @@ fn compile_source(source: &str) -> crate::vm::bytecode::Chunk {
     compiler::compile(&program).expect("compile")
 }
 
+fn compile_source_result(
+    source: &str,
+) -> Result<crate::vm::bytecode::Chunk, compiler::CompileError> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex");
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse_program().expect("parse");
+    compiler::compile(&program)
+}
+
 #[test]
 fn vm_error_stack_trace_reports_top_level_line() {
     // Three blank lines so the failing statement is on line 4 — we want
@@ -474,6 +484,7 @@ fn vm_error_stack_trace_reports_top_level_line() {
         "expected top-level frame to report line >= 4, got line {}",
         top.line
     );
+    assert!(top.col > 0, "expected top-level frame to report a column");
 }
 
 #[test]
@@ -507,6 +518,12 @@ let _ = inner()
         "expected `<main>` in trace, got: {:?}",
         function_names
     );
+    let inner = err
+        .stack_trace
+        .iter()
+        .find(|f| f.function == "inner")
+        .expect("inner frame");
+    assert!(inner.col > 0, "expected inner frame to report a column");
 }
 
 #[test]
@@ -528,6 +545,34 @@ fn vm_error_display_includes_trace() {
         rendered.contains("(line "),
         "expected `(line N)` in Display output, got: {}",
         rendered
+    );
+    assert!(
+        rendered.contains(", col "),
+        "expected `(line N, col M)` in Display output, got: {}",
+        rendered
+    );
+}
+
+#[test]
+fn vm_compiler_rejects_standalone_decorator() {
+    let err = compile_source_result("@server(port: 8080)\n")
+        .expect_err("standalone decorators must not silently compile");
+
+    assert!(
+        err.message
+            .contains("VM does not support standalone decorator"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn vm_compiler_accepts_metadata_function_decorator() {
+    let result = compile_source_result("@test\nfn sample() { return 1 }\n");
+    assert!(
+        result.is_ok(),
+        "metadata decorators attached to functions should still compile: {:?}",
+        result.err().map(|e| e.message)
     );
 }
 

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -240,6 +240,7 @@ pub struct VMError {
 pub struct StackFrame {
     pub function: String,
     pub line: usize,
+    pub col: usize,
 }
 
 impl VMError {
@@ -278,7 +279,15 @@ impl std::fmt::Display for VMError {
         write!(f, "{}", self.message)?;
         if !self.stack_trace.is_empty() {
             for frame in &self.stack_trace {
-                write!(f, "\n  at {} (line {})", frame.function, frame.line)?;
+                if frame.col > 0 {
+                    write!(
+                        f,
+                        "\n  at {} (line {}, col {})",
+                        frame.function, frame.line, frame.col
+                    )?;
+                } else {
+                    write!(f, "\n  at {} (line {})", frame.function, frame.line)?;
+                }
             }
         }
         Ok(())
@@ -2496,9 +2505,15 @@ impl VM {
                     } else {
                         0
                     };
+                    let col = if frame.ip > 0 && frame.ip - 1 < c.function.chunk.cols.len() {
+                        c.function.chunk.cols[frame.ip - 1]
+                    } else {
+                        0
+                    };
                     trace.push(StackFrame {
                         function: c.function.name.clone(),
                         line,
+                        col,
                     });
                 }
             }

--- a/src/vm/serialize.rs
+++ b/src/vm/serialize.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read, Write};
 
 const MAGIC: &[u8; 4] = b"FGC\0";
 const VERSION_MAJOR: u8 = 1;
-const VERSION_MINOR: u8 = 1;
+const VERSION_MINOR: u8 = 2;
 
 #[derive(Debug)]
 pub struct SerializeError {
@@ -67,6 +67,11 @@ fn write_chunk_inner(w: &mut Vec<u8>, chunk: &Chunk) -> Result<(), SerializeErro
     write_u32(w, chunk.lines.len() as u32)?;
     for &line in &chunk.lines {
         write_u32(w, line as u32)?;
+    }
+
+    write_u32(w, chunk.cols.len() as u32)?;
+    for &col in &chunk.cols {
+        write_u32(w, col as u32)?;
     }
 
     write_u16(w, chunk.prototypes.len() as u16)?;
@@ -157,17 +162,17 @@ fn read_chunk_root<R: Read>(r: &mut R) -> Result<Chunk, SerializeError> {
 
     let mut version = [0u8; 2];
     r.read_exact(&mut version)?;
-    if version[0] > VERSION_MAJOR {
+    if version[0] > VERSION_MAJOR || (version[0] == VERSION_MAJOR && version[1] > VERSION_MINOR) {
         return Err(SerializeError::new(&format!(
             "bytecode version {}.{} is newer than supported {}.{}",
             version[0], version[1], VERSION_MAJOR, VERSION_MINOR
         )));
     }
 
-    read_chunk_inner(r)
+    read_chunk_inner(r, version[1])
 }
 
-fn read_chunk_inner<R: Read>(r: &mut R) -> Result<Chunk, SerializeError> {
+fn read_chunk_inner<R: Read>(r: &mut R, minor_version: u8) -> Result<Chunk, SerializeError> {
     let name = read_string(r)?;
 
     let mut meta = [0u8; 3];
@@ -202,6 +207,34 @@ fn read_chunk_inner<R: Read>(r: &mut R) -> Result<Chunk, SerializeError> {
     for _ in 0..lines_count {
         lines.push(read_u32(r)? as usize);
     }
+    if lines.len() != code.len() {
+        return Err(SerializeError::new(&format!(
+            "line table length {} does not match code length {}",
+            lines.len(),
+            code.len()
+        )));
+    }
+
+    let cols = if minor_version >= 2 {
+        let cols_count = read_u32(r)? as usize;
+        if cols_count > 1_000_000 {
+            return Err(SerializeError::new("column table too large"));
+        }
+        let mut cols = Vec::with_capacity(cols_count);
+        for _ in 0..cols_count {
+            cols.push(read_u32(r)? as usize);
+        }
+        if cols.len() != code.len() {
+            return Err(SerializeError::new(&format!(
+                "column table length {} does not match code length {}",
+                cols.len(),
+                code.len()
+            )));
+        }
+        cols
+    } else {
+        vec![0; code.len()]
+    };
 
     let proto_count = read_u16(r)? as usize;
     if proto_count > 65536 {
@@ -209,7 +242,7 @@ fn read_chunk_inner<R: Read>(r: &mut R) -> Result<Chunk, SerializeError> {
     }
     let mut prototypes = Vec::with_capacity(proto_count);
     for _ in 0..proto_count {
-        prototypes.push(read_chunk_inner(r)?);
+        prototypes.push(read_chunk_inner(r, minor_version)?);
     }
 
     let uv_sources_count = read_u16(r)? as usize;
@@ -234,6 +267,7 @@ fn read_chunk_inner<R: Read>(r: &mut R) -> Result<Chunk, SerializeError> {
         code,
         constants,
         lines,
+        cols,
         name,
         prototypes,
         max_registers,
@@ -332,8 +366,81 @@ mod tests {
         assert_eq!(original.upvalue_count, restored.upvalue_count);
         assert_eq!(original.code, restored.code);
         assert_eq!(original.lines, restored.lines);
+        assert_eq!(original.cols, restored.cols);
         assert_eq!(original.constants.len(), restored.constants.len());
         assert_eq!(original.prototypes.len(), restored.prototypes.len());
+    }
+
+    #[test]
+    fn round_trip_columns() {
+        let mut original = Chunk::new("<columns>");
+        original.max_registers = 1;
+        original.emit_at(encode_abc(OpCode::LoadNull, 0, 0, 0), 7, 13);
+        original.emit_at(encode_abc(OpCode::Return, 0, 0, 0), 8, 5);
+
+        let bytes = serialize_chunk(&original).unwrap();
+        let restored = deserialize_chunk(&bytes).unwrap();
+
+        assert_eq!(original.lines, restored.lines);
+        assert_eq!(original.cols, restored.cols);
+    }
+
+    fn serialize_chunk_v1_1(chunk: &Chunk) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(MAGIC);
+        bytes.push(1);
+        bytes.push(1);
+        write_string(&mut bytes, &chunk.name).unwrap();
+        bytes.push(chunk.arity);
+        bytes.push(chunk.max_registers);
+        bytes.push(chunk.upvalue_count);
+
+        write_u32(&mut bytes, chunk.constants.len() as u32).unwrap();
+        for constant in &chunk.constants {
+            write_constant(&mut bytes, constant).unwrap();
+        }
+
+        write_u32(&mut bytes, chunk.code.len() as u32).unwrap();
+        for &instruction in &chunk.code {
+            write_u32(&mut bytes, instruction).unwrap();
+        }
+
+        write_u32(&mut bytes, chunk.lines.len() as u32).unwrap();
+        for &line in &chunk.lines {
+            write_u32(&mut bytes, line as u32).unwrap();
+        }
+
+        write_u16(&mut bytes, chunk.prototypes.len() as u16).unwrap();
+        for prototype in &chunk.prototypes {
+            bytes.extend_from_slice(&serialize_chunk_v1_1(prototype)[6..]);
+        }
+
+        write_u16(&mut bytes, chunk.upvalue_sources.len() as u16).unwrap();
+        for &src in &chunk.upvalue_sources {
+            match src {
+                UpvalueSource::Local(reg) => {
+                    bytes.push(0x01);
+                    bytes.push(reg);
+                }
+                UpvalueSource::Upvalue(idx) => {
+                    bytes.push(0x02);
+                    bytes.push(idx);
+                }
+            }
+        }
+
+        bytes
+    }
+
+    #[test]
+    fn deserializes_v1_1_without_columns_as_zero_columns() {
+        let original = make_simple_chunk();
+        let bytes = serialize_chunk_v1_1(&original);
+        let restored = deserialize_chunk(&bytes).unwrap();
+
+        assert_eq!(restored.code, original.code);
+        assert_eq!(restored.lines, original.lines);
+        assert_eq!(restored.cols, vec![0; restored.code.len()]);
     }
 
     #[test]
@@ -524,6 +631,17 @@ mod tests {
     }
 
     #[test]
+    fn future_minor_version_rejected() {
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC);
+        data.push(VERSION_MAJOR);
+        data.push(VERSION_MINOR + 1);
+        let result = deserialize_chunk(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("newer than supported"));
+    }
+
+    #[test]
     fn truncated_data_rejected() {
         let chunk = make_simple_chunk();
         let bytes = serialize_chunk(&chunk).unwrap();
@@ -606,6 +724,7 @@ println(result)
 
         assert_eq!(chunk.code, restored.code);
         assert_eq!(chunk.lines, restored.lines);
+        assert_eq!(chunk.cols, restored.cols);
         assert_eq!(chunk.name, restored.name);
         assert_eq!(chunk.arity, restored.arity);
         assert_eq!(chunk.max_registers, restored.max_registers);
@@ -617,6 +736,7 @@ println(result)
 
         for (orig, rest) in chunk.prototypes.iter().zip(restored.prototypes.iter()) {
             assert_eq!(orig.code, rest.code);
+            assert_eq!(orig.cols, rest.cols);
             assert_eq!(orig.name, rest.name);
             assert_eq!(orig.arity, rest.arity);
             for (oc, rc) in orig.constants.iter().zip(rest.constants.iter()) {
@@ -658,6 +778,7 @@ println(result)
         let orig_fib = &chunk.prototypes[0];
         let rest_fib = &restored.prototypes[0];
         assert_eq!(orig_fib.code, rest_fib.code);
+        assert_eq!(orig_fib.cols, rest_fib.cols);
         assert_eq!(orig_fib.name, rest_fib.name);
         assert_eq!(orig_fib.arity, rest_fib.arity);
     }
@@ -688,6 +809,7 @@ println(sum)
 
         assert_eq!(chunk.code, restored.code);
         assert_eq!(chunk.lines, restored.lines);
+        assert_eq!(chunk.cols, restored.cols);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Carry parser columns through VM bytecode emission and runtime stack traces so VM errors can render `line N, col M`.
- Bump Forge bytecode serialization to v1.2 with a column table while keeping v1.1 bytecode readable by synthesizing zero columns.
- Reject standalone decorator statements during direct VM compilation instead of silently dropping them, while preserving metadata decorators on functions.

## Test plan
- `cargo test vm_error_stack_trace --lib`
- `cargo test vm_error_display --lib`
- `cargo test vm_compiler_ --lib`
- `cargo test serialize --lib`
- `cargo test parity_corpus_`
- `cargo test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VM error traces now display source column information alongside line numbers for improved debugging

* **Bug Fixes**
  * Standalone decorator statements now fail at compile time instead of being silently ignored
  * Function-attached metadata decorators are properly preserved

* **Improvements**
  * Backward compatibility maintained for older bytecode formats with automatic column handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->