### PR TITLE
test(cli): pin JIT limitation help text

### DIFF
--- a/.planning/jit-help-limitation.plan.md
+++ b/.planning/jit-help-limitation.plan.md
@@ -1,0 +1,33 @@
+# JIT Help Limitation Plan
+
+## Goal
+
+Close production-readiness item E3 by making the JIT limitation explicit and tested.
+
+## Current State
+
+- `src/main.rs` already documents `--jit` as numeric-leaf-function focused in the clap help text.
+- There is no test pinning that wording, so future CLI edits can accidentally erase the warning.
+- Runtime `run_jit` already prints per-function `JIT compiled` / `JIT skip` diagnostics, so adding a new runtime notice would likely add noisy stderr churn.
+
+## Implementation
+
+Expert review approved this as test-only hardening. Do not add a runtime notice; `run_jit` already emits per-function compile/skip diagnostics and extra stderr would be noisy.
+
+1. Add `CommandFactory` import from `clap`.
+2. Add a focused unit test in `src/main.rs` tests that renders long help (`Cli::command().render_long_help().to_string()`).
+3. Assert the help includes:
+   - `--jit`
+   - `JIT-compile numeric leaf functions`
+   - `falls back to the bytecode interpreter automatically`
+4. Keep the test unconditional because the help text is unconditional.
+5. Update `CHANGELOG.md` only if the help text itself changes. If this is test-only hardening, skip changelog.
+
+## Tests
+
+- `cargo test jit_help --lib` if the test is in lib-visible code, otherwise `cargo test jit_help`
+- `cargo test`
+
+## Rollback
+
+Remove the test/import. No runtime behavior changes expected.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::process;
 
+#[cfg(test)]
+use clap::CommandFactory;
 use clap::{Parser, Subcommand};
 
 use interpreter::Interpreter;
@@ -1103,6 +1105,15 @@ fn run_bytecode_file(file_path: &PathBuf, profile: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jit_help_documents_numeric_limit_and_vm_fallback() {
+        let help = Cli::command().render_long_help().to_string();
+
+        assert!(help.contains("--jit"));
+        assert!(help.contains("JIT-compile numeric leaf functions"));
+        assert!(help.contains("falls back to the bytecode interpreter automatically"));
+    }
 
     #[test]
     fn parity_corpus_supported_cases() {


### PR DESCRIPTION
## Summary
- Pins the `--jit` long-help text so it continues to document numeric-function scope and automatic VM fallback.
- Captures the production-readiness E3 decision as a plan artifact without changing runtime behavior.

## Test plan
- [x] `cargo test jit_help`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test validating CLI help text for `--jit` flag explicitly documents numeric-leaf-function compilation scope and interpreter fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->