### PR TITLE
feat(mysql): add explicit transaction handles

### DIFF
--- a/.planning/db-transaction-apis.plan.md
+++ b/.planning/db-transaction-apis.plan.md
@@ -1,0 +1,98 @@
+# DB Transaction APIs Plan
+
+## Goal
+
+Close production-readiness F1 by making transaction APIs consistently available across `db`, `pg`, and `mysql`.
+
+## Current State
+
+- `db` already exposes `db.begin`, `db.commit`, and `db.rollback` as raw `BEGIN` / `COMMIT` / `ROLLBACK` on the single SQLite connection.
+- `db` already has commit and rollback unit tests.
+- `pg` already exposes `pg.begin`, `pg.commit`, and `pg.rollback` through `batch_execute` on the stored `Arc<Client>`.
+- `pg` has no live transaction test because tests do not provision Postgres.
+- `mysql` intentionally does not expose transaction helpers today. The current pool-based `mysql.query` / `mysql.execute` acquire a fresh pooled connection per call, so a naive `BEGIN` followed by later `COMMIT` could run on different physical connections and silently fail transaction semantics.
+
+## API
+
+- Keep existing APIs:
+  - `db.begin()`, `db.commit()`, `db.rollback()`
+  - `pg.begin()`, `pg.commit()`, `pg.rollback()`
+- Add MySQL APIs with explicit transaction handles:
+  - `let tx = mysql.begin(conn_id)`
+  - `mysql.query(tx, sql, params?)`
+  - `mysql.execute(tx, sql, params?)`
+  - `mysql.commit(tx)`
+  - `mysql.rollback(tx)`
+
+`mysql.begin` deliberately returns an opaque transaction id instead of making
+the original pooled `conn_id` transactional. This avoids changing a process-wide
+pooled connection id into implicit mutable transaction state that could be
+shared across HTTP request forks or unrelated interpreter sessions.
+
+## Implementation
+
+1. Add `mysql.begin`, `mysql.commit`, and `mysql.rollback` to `mysql::create_module()` and dispatch.
+2. Add an active-transaction map:
+   - key: opaque Forge MySQL transaction id (`mysql_tx_<uuid>`)
+   - value: active transaction record containing the origin pool connection id and `Arc<tokio::sync::Mutex<mysql_async::Conn>>`
+   - the map is process-global (`OnceLock`) like the existing MySQL pool map, so transaction handle strings survive interpreter forks and resolve to the same physical pinned connection. This is intentional and matches the existing pool-id semantics; callers must not leak tx ids across unrelated requests if they want isolation.
+3. `mysql.begin(conn_id)`:
+   - fail if `conn_id` is not known in the pool map
+   - get one pooled connection
+   - execute raw `BEGIN`
+   - generate a UUID-backed transaction id
+   - store that physical connection in the transaction map under the transaction id
+   - return the transaction id as a string
+4. `mysql.query` and `mysql.execute`:
+   - treat the first string argument as either a transaction id or a pool connection id
+   - first check for an active transaction connection for that id
+   - if present, run on that pinned connection
+   - otherwise keep current pooled one-shot behavior
+5. `mysql.commit(tx_id)` / `mysql.rollback(tx_id)`:
+   - execute raw `COMMIT` / `ROLLBACK` on that exact connection
+   - only remove the pinned connection from the transaction map after successful completion
+   - if commit/rollback fails, leave the transaction handle present so the caller can retry or rollback
+   - return `Null`
+   - fail if no transaction is active for the supplied id
+6. `mysql.close(conn_id)`:
+   - check whether any active transaction record originated from `conn_id`
+   - if yes, return an error refusing to close until the caller commits or rolls back those tx handles
+   - if no, keep existing pool removal behavior
+7. Concurrency:
+   - query/execute/commit/rollback lock the transaction connection while the SQL operation is in flight
+   - this serializes operations on the same transaction handle and prevents concurrent protocol use on one MySQL connection
+   - separate transaction handles use separate pooled physical connections
+
+## Tests
+
+- SQLite: keep existing commit/rollback tests; run `cargo test stdlib::db --lib`.
+- Postgres: keep current no-connection error-path coverage; do not add a fake live test without a provisioned server. If a `FORGE_PG_TEST_URL` convention already exists, add an ignored/env-gated live transaction test; otherwise leave live coverage for integration infrastructure.
+- MySQL:
+  - module exposes `begin`, `commit`, `rollback`
+  - wrong/missing connection id errors for begin
+  - wrong/missing transaction id errors for commit/rollback
+  - `mysql.query` / `mysql.execute` continue to error for unknown ids
+  - if `FORGE_MYSQL_TEST_URL` is set, add an ignored/env-gated live test covering:
+    - `begin(conn)` returns a tx id distinct from the connection id
+    - `execute(tx, insert)` followed by `rollback(tx)` leaves row absent
+    - `execute(tx, insert)` followed by `commit(tx)` leaves row present
+    - concurrent transactions from the same pool id do not see each other's uncommitted writes
+    - concurrent operations on the same tx handle serialize without panic/deadlock
+    - `mysql.close(conn)` refuses while a tx from that pool is outstanding
+- Always run:
+  - `cargo fmt`
+  - `cargo test stdlib::db --lib`
+  - `cargo test stdlib::pg --lib`
+  - `cargo test stdlib::mysql --lib`
+  - `cargo test`
+
+## Rollback
+
+Remove the MySQL transaction map and the three MySQL dispatch arms. SQLite and Postgres remain unchanged.
+
+## Deferred
+
+- Moving DB handles into interpreter-scoped state would be cleaner long term, but today `db`, `pg`, and `mysql` are all stdlib modules backed by module-local process/thread state. This plan avoids adding implicit per-connection transaction state and uses opaque transaction ids to keep MySQL transaction ownership explicit.
+- Live Postgres/MySQL transaction tests require provisioned services. This PR can add env-gated tests, but normal CI will still rely on unit tests unless service containers are added later.
+- Forgotten MySQL transaction handles pin a connection until commit/rollback or process exit. TTL/cleanup sweeps are deferred.
+- Nested transactions / SAVEPOINT support are deferred.

--- a/src/stdlib/mysql.rs
+++ b/src/stdlib/mysql.rs
@@ -414,18 +414,22 @@ fn mysql_finish_tx(
     };
 
     run_mysql(async move {
-        let mut tx_guard = mysql_transactions().lock().await;
-        let tx = tx_guard
-            .get(&tx_id)
-            .cloned()
-            .ok_or_else(|| format!("MySQL transaction '{}' not found", tx_id))?;
+        let tx = {
+            let tx_guard = mysql_transactions().lock().await;
+            tx_guard
+                .get(&tx_id)
+                .cloned()
+                .ok_or_else(|| format!("MySQL transaction '{}' not found", tx_id))?
+        };
 
         let mut conn = tx.conn.lock().await;
         use mysql_async::prelude::*;
         conn.query_drop(stmt)
             .await
             .map_err(|e| format!("{}() error: {}", label, e))?;
-        tx_guard.remove(&tx_id);
+        drop(conn);
+
+        mysql_transactions().lock().await.remove(&tx_id);
 
         Ok(Value::Null)
     })
@@ -679,6 +683,18 @@ mod tests {
             .expect("insert commit row");
             call("mysql.commit", vec![Value::String(commit_tx_id)]).expect("commit");
             assert_eq!(count_rows(&conn_id, &table), 1);
+
+            let close_guard_tx =
+                call("mysql.begin", vec![Value::String(conn_id.clone())]).expect("begin close tx");
+            let close_guard_tx_id = match close_guard_tx {
+                Value::String(id) => id,
+                other => panic!("expected tx id, got {other:?}"),
+            };
+            let close_result = call("mysql.close", vec![Value::String(conn_id.clone())]);
+            assert!(close_result.is_err());
+            assert!(close_result.unwrap_err().contains("active transactions"));
+            call("mysql.rollback", vec![Value::String(close_guard_tx_id)])
+                .expect("rollback close guard tx");
 
             call(
                 "mysql.execute",

--- a/src/stdlib/mysql.rs
+++ b/src/stdlib/mysql.rs
@@ -1,7 +1,7 @@
 use crate::interpreter::Value;
 use indexmap::IndexMap;
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 pub fn create_module() -> Value {
     let mut m = IndexMap::new();
@@ -21,12 +21,18 @@ pub fn create_module() -> Value {
         "close".to_string(),
         Value::BuiltIn("mysql.close".to_string()),
     );
-    // NOTE: mysql.begin/commit/rollback are intentionally absent. mysql_async's
-    // pool returns a fresh connection on every get_conn(), so issuing BEGIN
-    // on one call and COMMIT on a later call would target different physical
-    // connections — silently broken transactions. For multi-statement work,
-    // use a dedicated transaction API (future) or run all statements inside a
-    // single SQL string via the underlying server's batch execution.
+    m.insert(
+        "begin".to_string(),
+        Value::BuiltIn("mysql.begin".to_string()),
+    );
+    m.insert(
+        "commit".to_string(),
+        Value::BuiltIn("mysql.commit".to_string()),
+    );
+    m.insert(
+        "rollback".to_string(),
+        Value::BuiltIn("mysql.rollback".to_string()),
+    );
     Value::Object(m)
 }
 
@@ -40,12 +46,26 @@ fn mysql_counter() -> &'static std::sync::Mutex<u64> {
     COUNTER.get_or_init(|| std::sync::Mutex::new(0))
 }
 
+#[derive(Clone)]
+struct ActiveMysqlTx {
+    origin_conn_id: String,
+    conn: Arc<tokio::sync::Mutex<mysql_async::Conn>>,
+}
+
+fn mysql_transactions() -> &'static tokio::sync::Mutex<HashMap<String, ActiveMysqlTx>> {
+    static TXS: OnceLock<tokio::sync::Mutex<HashMap<String, ActiveMysqlTx>>> = OnceLock::new();
+    TXS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
 pub fn call(name: &str, args: Vec<Value>) -> Result<Value, String> {
     match name {
         "mysql.connect" => mysql_connect(args),
         "mysql.query" => mysql_query(args),
         "mysql.execute" => mysql_execute(args),
         "mysql.close" => mysql_close(args),
+        "mysql.begin" => mysql_begin(args),
+        "mysql.commit" => mysql_finish_tx(args, "COMMIT", "mysql.commit"),
+        "mysql.rollback" => mysql_finish_tx(args, "ROLLBACK", "mysql.rollback"),
         _ => Err(format!("unknown mysql function: {}", name)),
     }
 }
@@ -171,7 +191,7 @@ fn mysql_connect(args: Vec<Value>) -> Result<Value, String> {
 }
 
 fn mysql_query(args: Vec<Value>) -> Result<Value, String> {
-    let conn_id = match args.first() {
+    let handle_id = match args.first() {
         Some(Value::String(s)) => s.clone(),
         _ => return Err("mysql.query() requires a connection ID as first argument".to_string()),
     };
@@ -186,10 +206,15 @@ fn mysql_query(args: Vec<Value>) -> Result<Value, String> {
     };
 
     run_mysql(async move {
+        if let Some(tx_conn) = active_mysql_tx_conn(&handle_id).await {
+            let mut conn = tx_conn.lock().await;
+            return query_on_mysql_conn(&mut conn, &sql, params).await;
+        }
+
         let pool_guard = mysql_pool().lock().await;
         let pool = pool_guard
-            .get(&conn_id)
-            .ok_or_else(|| format!("MySQL connection '{}' not found", conn_id))?;
+            .get(&handle_id)
+            .ok_or_else(|| format!("MySQL connection '{}' not found", handle_id))?;
         let pool_clone = pool.clone();
         drop(pool_guard);
 
@@ -198,38 +223,12 @@ fn mysql_query(args: Vec<Value>) -> Result<Value, String> {
             .await
             .map_err(|e| format!("mysql.query() connection error: {}", e))?;
 
-        use mysql_async::prelude::*;
-
-        let rows: Vec<mysql_async::Row> = if params.is_empty() {
-            conn.query(&sql)
-                .await
-                .map_err(|e| format!("mysql.query() error: {}", e))?
-        } else {
-            conn.exec(&sql, mysql_async::Params::Positional(params))
-                .await
-                .map_err(|e| format!("mysql.query() error: {}", e))?
-        };
-
-        let mut results = Vec::new();
-        for row in rows {
-            let mut map = IndexMap::new();
-            let columns: Vec<String> = row
-                .columns_ref()
-                .iter()
-                .map(|c| c.name_str().to_string())
-                .collect();
-            for (i, col_name) in columns.iter().enumerate() {
-                let val: mysql_async::Value = row.get(i).unwrap_or(mysql_async::Value::NULL);
-                map.insert(col_name.clone(), mysql_val_to_forge(val));
-            }
-            results.push(Value::Object(map));
-        }
-        Ok(Value::Array(results))
+        query_on_mysql_conn(&mut conn, &sql, params).await
     })
 }
 
 fn mysql_execute(args: Vec<Value>) -> Result<Value, String> {
-    let conn_id = match args.first() {
+    let handle_id = match args.first() {
         Some(Value::String(s)) => s.clone(),
         _ => return Err("mysql.execute() requires a connection ID as first argument".to_string()),
     };
@@ -246,10 +245,15 @@ fn mysql_execute(args: Vec<Value>) -> Result<Value, String> {
     };
 
     run_mysql(async move {
+        if let Some(tx_conn) = active_mysql_tx_conn(&handle_id).await {
+            let mut conn = tx_conn.lock().await;
+            return execute_on_mysql_conn(&mut conn, &sql, params).await;
+        }
+
         let pool_guard = mysql_pool().lock().await;
         let pool = pool_guard
-            .get(&conn_id)
-            .ok_or_else(|| format!("MySQL connection '{}' not found", conn_id))?;
+            .get(&handle_id)
+            .ok_or_else(|| format!("MySQL connection '{}' not found", handle_id))?;
         let pool_clone = pool.clone();
         drop(pool_guard);
 
@@ -258,19 +262,7 @@ fn mysql_execute(args: Vec<Value>) -> Result<Value, String> {
             .await
             .map_err(|e| format!("mysql.execute() connection error: {}", e))?;
 
-        use mysql_async::prelude::*;
-
-        if params.is_empty() {
-            conn.query_drop(&sql)
-                .await
-                .map_err(|e| format!("mysql.execute() error: {}", e))?;
-        } else {
-            conn.exec_drop(&sql, mysql_async::Params::Positional(params))
-                .await
-                .map_err(|e| format!("mysql.execute() error: {}", e))?;
-        }
-
-        Ok(Value::Int(conn.affected_rows() as i64))
+        execute_on_mysql_conn(&mut conn, &sql, params).await
     })
 }
 
@@ -281,6 +273,27 @@ fn mysql_close(args: Vec<Value>) -> Result<Value, String> {
     };
 
     run_mysql(async move {
+        let outstanding: Vec<String> = {
+            let tx_guard = mysql_transactions().lock().await;
+            tx_guard
+                .iter()
+                .filter_map(|(tx_id, tx)| {
+                    if tx.origin_conn_id == conn_id {
+                        Some(tx_id.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+        if !outstanding.is_empty() {
+            return Err(format!(
+                "mysql.close() refused: active transactions for {}: {}",
+                conn_id,
+                outstanding.join(", ")
+            ));
+        }
+
         let mut pool_guard = mysql_pool().lock().await;
         if let Some(pool) = pool_guard.remove(&conn_id) {
             drop(pool_guard);
@@ -291,6 +304,130 @@ fn mysql_close(args: Vec<Value>) -> Result<Value, String> {
         } else {
             Ok(Value::Bool(false))
         }
+    })
+}
+
+async fn active_mysql_tx_conn(id: &str) -> Option<Arc<tokio::sync::Mutex<mysql_async::Conn>>> {
+    let tx_guard = mysql_transactions().lock().await;
+    tx_guard.get(id).map(|tx| Arc::clone(&tx.conn))
+}
+
+async fn query_on_mysql_conn(
+    conn: &mut mysql_async::Conn,
+    sql: &str,
+    params: Vec<mysql_async::Value>,
+) -> Result<Value, String> {
+    use mysql_async::prelude::*;
+
+    let rows: Vec<mysql_async::Row> = if params.is_empty() {
+        conn.query(sql)
+            .await
+            .map_err(|e| format!("mysql.query() error: {}", e))?
+    } else {
+        conn.exec(sql, mysql_async::Params::Positional(params))
+            .await
+            .map_err(|e| format!("mysql.query() error: {}", e))?
+    };
+
+    let mut results = Vec::new();
+    for row in rows {
+        let mut map = IndexMap::new();
+        let columns: Vec<String> = row
+            .columns_ref()
+            .iter()
+            .map(|c| c.name_str().to_string())
+            .collect();
+        for (i, col_name) in columns.iter().enumerate() {
+            let val: mysql_async::Value = row.get(i).unwrap_or(mysql_async::Value::NULL);
+            map.insert(col_name.clone(), mysql_val_to_forge(val));
+        }
+        results.push(Value::Object(map));
+    }
+    Ok(Value::Array(results))
+}
+
+async fn execute_on_mysql_conn(
+    conn: &mut mysql_async::Conn,
+    sql: &str,
+    params: Vec<mysql_async::Value>,
+) -> Result<Value, String> {
+    use mysql_async::prelude::*;
+
+    if params.is_empty() {
+        conn.query_drop(sql)
+            .await
+            .map_err(|e| format!("mysql.execute() error: {}", e))?;
+    } else {
+        conn.exec_drop(sql, mysql_async::Params::Positional(params))
+            .await
+            .map_err(|e| format!("mysql.execute() error: {}", e))?;
+    }
+
+    Ok(Value::Int(conn.affected_rows() as i64))
+}
+
+fn mysql_begin(args: Vec<Value>) -> Result<Value, String> {
+    let conn_id = match args.first() {
+        Some(Value::String(s)) => s.clone(),
+        _ => return Err("mysql.begin() requires a connection ID".to_string()),
+    };
+
+    run_mysql(async move {
+        let pool_guard = mysql_pool().lock().await;
+        let pool = pool_guard
+            .get(&conn_id)
+            .ok_or_else(|| format!("MySQL connection '{}' not found", conn_id))?;
+        let pool_clone = pool.clone();
+        drop(pool_guard);
+
+        let mut conn = pool_clone
+            .get_conn()
+            .await
+            .map_err(|e| format!("mysql.begin() connection error: {}", e))?;
+
+        use mysql_async::prelude::*;
+        conn.query_drop("BEGIN")
+            .await
+            .map_err(|e| format!("mysql.begin() error: {}", e))?;
+
+        let tx_id = format!("mysql_tx_{}", uuid::Uuid::new_v4());
+        mysql_transactions().lock().await.insert(
+            tx_id.clone(),
+            ActiveMysqlTx {
+                origin_conn_id: conn_id,
+                conn: Arc::new(tokio::sync::Mutex::new(conn)),
+            },
+        );
+
+        Ok(Value::String(tx_id))
+    })
+}
+
+fn mysql_finish_tx(
+    args: Vec<Value>,
+    stmt: &'static str,
+    label: &'static str,
+) -> Result<Value, String> {
+    let tx_id = match args.first() {
+        Some(Value::String(s)) => s.clone(),
+        _ => return Err(format!("{}() requires a transaction ID", label)),
+    };
+
+    run_mysql(async move {
+        let mut tx_guard = mysql_transactions().lock().await;
+        let tx = tx_guard
+            .get(&tx_id)
+            .cloned()
+            .ok_or_else(|| format!("MySQL transaction '{}' not found", tx_id))?;
+
+        let mut conn = tx.conn.lock().await;
+        use mysql_async::prelude::*;
+        conn.query_drop(stmt)
+            .await
+            .map_err(|e| format!("{}() error: {}", label, e))?;
+        tx_guard.remove(&tx_id);
+
+        Ok(Value::Null)
     })
 }
 
@@ -320,7 +457,10 @@ mod tests {
             assert!(m.contains_key("query"));
             assert!(m.contains_key("execute"));
             assert!(m.contains_key("close"));
-            assert_eq!(m.len(), 4);
+            assert!(m.contains_key("begin"));
+            assert!(m.contains_key("commit"));
+            assert!(m.contains_key("rollback"));
+            assert_eq!(m.len(), 7);
         } else {
             panic!("expected object module");
         }
@@ -438,5 +578,138 @@ mod tests {
         let result = mysql_execute(vec![Value::String("mysql_1".to_string())]);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("SQL string"));
+    }
+
+    #[test]
+    fn test_begin_missing_conn_id() {
+        let result = mysql_begin(vec![]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection ID"));
+    }
+
+    #[test]
+    fn test_begin_unknown_conn_id() {
+        let result = mysql_begin(vec![Value::String("mysql_missing".to_string())]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn test_commit_missing_tx_id() {
+        let result = mysql_finish_tx(vec![], "COMMIT", "mysql.commit");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("transaction ID"));
+    }
+
+    #[test]
+    fn test_commit_unknown_tx_id() {
+        let result = mysql_finish_tx(
+            vec![Value::String("mysql_tx_missing".to_string())],
+            "COMMIT",
+            "mysql.commit",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    #[ignore = "requires FORGE_MYSQL_TEST_URL pointing at a disposable MySQL database"]
+    fn live_transactions_commit_and_rollback() {
+        let url = match std::env::var("FORGE_MYSQL_TEST_URL") {
+            Ok(url) => url,
+            Err(_) => return,
+        };
+        let table = format!("forge_tx_test_{}", std::process::id());
+        let rt = tokio::runtime::Runtime::new().expect("test runtime");
+
+        rt.block_on(async {
+            let conn = call("mysql.connect", vec![Value::String(url)]).expect("connect");
+            let conn_id = match conn {
+                Value::String(id) => id,
+                other => panic!("expected connection id, got {other:?}"),
+            };
+
+            call(
+                "mysql.execute",
+                vec![
+                    Value::String(conn_id.clone()),
+                    Value::String(format!("DROP TABLE IF EXISTS {table}")),
+                ],
+            )
+            .expect("drop table");
+            call(
+                "mysql.execute",
+                vec![
+                    Value::String(conn_id.clone()),
+                    Value::String(format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY)")),
+                ],
+            )
+            .expect("create table");
+
+            let rollback_tx = call("mysql.begin", vec![Value::String(conn_id.clone())])
+                .expect("begin rollback tx");
+            let rollback_tx_id = match rollback_tx {
+                Value::String(id) => id,
+                other => panic!("expected tx id, got {other:?}"),
+            };
+            call(
+                "mysql.execute",
+                vec![
+                    Value::String(rollback_tx_id.clone()),
+                    Value::String(format!("INSERT INTO {table} VALUES (1)")),
+                ],
+            )
+            .expect("insert rollback row");
+            call("mysql.rollback", vec![Value::String(rollback_tx_id)]).expect("rollback");
+            assert_eq!(count_rows(&conn_id, &table), 0);
+
+            let commit_tx =
+                call("mysql.begin", vec![Value::String(conn_id.clone())]).expect("begin commit tx");
+            let commit_tx_id = match commit_tx {
+                Value::String(id) => id,
+                other => panic!("expected tx id, got {other:?}"),
+            };
+            call(
+                "mysql.execute",
+                vec![
+                    Value::String(commit_tx_id.clone()),
+                    Value::String(format!("INSERT INTO {table} VALUES (2)")),
+                ],
+            )
+            .expect("insert commit row");
+            call("mysql.commit", vec![Value::String(commit_tx_id)]).expect("commit");
+            assert_eq!(count_rows(&conn_id, &table), 1);
+
+            call(
+                "mysql.execute",
+                vec![
+                    Value::String(conn_id.clone()),
+                    Value::String(format!("DROP TABLE IF EXISTS {table}")),
+                ],
+            )
+            .expect("cleanup table");
+            call("mysql.close", vec![Value::String(conn_id)]).expect("close");
+        });
+    }
+
+    fn count_rows(conn_id: &str, table: &str) -> i64 {
+        let result = call(
+            "mysql.query",
+            vec![
+                Value::String(conn_id.to_string()),
+                Value::String(format!("SELECT COUNT(*) AS n FROM {table}")),
+            ],
+        )
+        .expect("count rows");
+        match result {
+            Value::Array(rows) => match rows.first() {
+                Some(Value::Object(row)) => match row.get("n") {
+                    Some(Value::Int(n)) => *n,
+                    other => panic!("expected integer count, got {other:?}"),
+                },
+                other => panic!("expected first row, got {other:?}"),
+            },
+            other => panic!("expected rows array, got {other:?}"),
+        }
     }
 }

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -763,7 +763,9 @@ impl VM {
         #[cfg(feature = "mysql")]
         {
             let mut mysql_map = IndexMap::new();
-            for name in &["connect", "query", "execute", "close"] {
+            for name in &[
+                "connect", "query", "execute", "close", "begin", "commit", "rollback",
+            ] {
                 let full = format!("mysql.{}", name);
                 let nr = self
                     .gc


### PR DESCRIPTION
## Summary
- Adds `mysql.begin`, `mysql.commit`, and `mysql.rollback` using opaque transaction ids so transaction statements run on one pinned physical MySQL connection.
- Keeps existing pooled `mysql.query` / `mysql.execute` behavior for normal connection ids while allowing the same calls to accept transaction ids.
- Refuses `mysql.close(conn_id)` while transaction handles from that pool are still active, avoiding silent pinned-connection leaks.

## Test plan
- [x] `cargo test stdlib::db --lib`
- [x] `cargo test stdlib::pg --lib`
- [x] `cargo test stdlib::mysql --lib`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MySQL module supports explicit transactions via mysql.begin(), mysql.commit(), and mysql.rollback(), enabling atomic multi-statement operations.
  * Attempting to close a pooled MySQL connection with active transactions now fails and reports the outstanding transaction handles.

* **Documentation**
  * Added a plan describing consistent transaction APIs across database modules.

* **Tests**
  * Added unit tests and optional env-gated live MySQL integration tests for transaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->