### PR TITLE
test(stdlib): cover remaining deterministic helpers

### DIFF
--- a/.planning/stdlib-coverage-gaps.plan.md
+++ b/.planning/stdlib-coverage-gaps.plan.md
@@ -1,0 +1,40 @@
+# Stdlib Coverage Gaps Plan
+
+## Goal
+
+Close production-readiness G1 by filling deterministic unit-test gaps in `crypto`, `regex`, `json`, and `time`.
+
+## Current State
+
+- `crypto.rs` already has broad happy-path vectors and basic error tests.
+- `regex_module.rs` already covers each public regex function plus invalid patterns and wrong args.
+- `json_module.rs` already covers parse/stringify/pretty/valid/merge and round-trips.
+- `time.rs` has strong coverage for parsing, formatting, arithmetic, zones, and calendar helpers, but its module-list test omits some exported functions and several deterministic public functions still lack direct tests.
+
+## Implementation
+
+1. Add missing `time` module export assertions for all functions in `create_module`.
+2. Add deterministic `time` tests for:
+   - `time.zone` converting a fixed timestamp to a named timezone
+   - `time.elapsed` / `time.measure` returning positive epoch milliseconds without asserting wall-clock precision
+   - `time.sleep(0)` returning quickly without timing flakes
+   - `time.local` returning an object tagged `Local`
+   - `time.is_weekend`, `time.is_weekday`, and `time.day_of_week`
+   - wrong-argument errors for representative time helpers
+3. Add a few small edge-case tests outside `time` only where they add signal:
+   - JSON rejects non-string map keys during stringify/pretty
+   - regex invalid pattern errors propagate from another public function, not just `test`
+   - crypto hash functions reject missing/wrong arguments consistently
+
+## Tests
+
+- `cargo fmt`
+- `cargo test stdlib::crypto --lib`
+- `cargo test stdlib::regex_module --lib`
+- `cargo test stdlib::json_module --lib`
+- `cargo test stdlib::time --lib`
+- `cargo test`
+
+## Rollback
+
+Remove the added unit tests and this plan file. No runtime behavior changes expected.

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -267,6 +267,9 @@ mod tests {
         assert!(call("crypto.sha256", vec![Value::Int(1)]).is_err());
         assert!(call("crypto.md5", vec![]).is_err());
         assert!(call("crypto.base64_encode", vec![Value::Bool(true)]).is_err());
+        assert!(call("crypto.sha512", vec![Value::Array(vec![])]).is_err());
+        assert!(call("crypto.hex_encode", vec![]).is_err());
+        assert!(call("crypto.hex_decode", vec![Value::Bool(false)]).is_err());
         assert!(call("crypto.random_bytes", vec![s("hi")]).is_err());
     }
 

--- a/src/stdlib/json_module.rs
+++ b/src/stdlib/json_module.rs
@@ -399,6 +399,16 @@ mod tests {
     }
 
     #[test]
+    fn stringify_rejects_non_string_map_keys() {
+        let result = call(
+            "json.stringify",
+            vec![Value::Map(vec![(Value::Int(1), s("one"))])],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("non-string key"));
+    }
+
+    #[test]
     fn pretty_indents_object() {
         let mut obj = IndexMap::new();
         obj.insert("a".to_string(), Value::Int(1));
@@ -417,6 +427,16 @@ mod tests {
         assert_eq!(result, s("[]"));
         let result = call("json.pretty", vec![Value::Object(IndexMap::new())]).unwrap();
         assert_eq!(result, s("{}"));
+    }
+
+    #[test]
+    fn pretty_rejects_non_string_map_keys() {
+        let result = call(
+            "json.pretty",
+            vec![Value::Map(vec![(Value::Bool(true), Value::Int(1))])],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("non-string key"));
     }
 
     #[test]

--- a/src/stdlib/regex_module.rs
+++ b/src/stdlib/regex_module.rs
@@ -158,6 +158,13 @@ mod tests {
     }
 
     #[test]
+    fn invalid_pattern_errors_from_replace_too() {
+        let result = call("regex.replace", vec![s("anything"), s(r"["), s("x")]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid regex"));
+    }
+
+    #[test]
     fn wrong_arg_types_error() {
         assert!(call("regex.test", vec![s("text")]).is_err());
         assert!(call("regex.find", vec![Value::Int(1), s(r"\d")]).is_err());

--- a/src/stdlib/time.rs
+++ b/src/stdlib/time.rs
@@ -736,6 +736,15 @@ mod tests {
                 "is_after",
                 "is_leap_year",
                 "days_in_month",
+                "elapsed",
+                "end_of",
+                "is_weekday",
+                "is_weekend",
+                "day_of_week",
+                "local",
+                "measure",
+                "sleep",
+                "zones",
             ] {
                 assert!(m.contains_key(k), "missing {}", k);
             }
@@ -772,6 +781,17 @@ mod tests {
         let result = call("time.now", vec![s("Mars/Olympus")]);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown timezone"));
+    }
+
+    #[test]
+    fn local_returns_local_timezone_object() {
+        let result = call("time.local", vec![]).unwrap();
+        if let Value::Object(m) = result {
+            assert_eq!(m.get("timezone"), Some(&s("Local")));
+            assert!(m.contains_key("unix"));
+        } else {
+            panic!("expected object");
+        }
     }
 
     #[test]
@@ -849,6 +869,19 @@ mod tests {
     }
 
     #[test]
+    fn zone_converts_fixed_timestamp() {
+        let t = call("time.from_unix", vec![Value::Int(1609459200)]).unwrap();
+        let result = call("time.zone", vec![t, s("America/New_York")]).unwrap();
+        if let Value::Object(m) = result {
+            assert_eq!(m.get("timezone"), Some(&s("America/New_York")));
+            assert_eq!(m.get("hour"), Some(&Value::Int(19)));
+            assert_eq!(m.get("day"), Some(&Value::Int(31)));
+        } else {
+            panic!("expected object");
+        }
+    }
+
+    #[test]
     fn diff_between_two_times() {
         let a = call("time.from_unix", vec![Value::Int(1000)]).unwrap();
         let b = call("time.from_unix", vec![Value::Int(100)]).unwrap();
@@ -875,6 +908,26 @@ mod tests {
     }
 
     #[test]
+    fn weekday_weekend_and_day_name_for_fixed_dates() {
+        let friday = call("time.parse", vec![s("2021-01-01")]).unwrap();
+        let saturday = call("time.parse", vec![s("2021-01-02")]).unwrap();
+
+        assert_eq!(
+            call("time.is_weekday", vec![friday.clone()]).unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            call("time.is_weekend", vec![friday.clone()]).unwrap(),
+            Value::Bool(false)
+        );
+        assert_eq!(call("time.day_of_week", vec![friday]).unwrap(), s("Friday"));
+        assert_eq!(
+            call("time.is_weekend", vec![saturday]).unwrap(),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
     fn add_duration_object() {
         let t = call("time.from_unix", vec![Value::Int(0)]).unwrap();
         let mut dur = IndexMap::new();
@@ -896,6 +949,20 @@ mod tests {
             assert_eq!(m.get("unix"), Some(&Value::Int(900)));
         } else {
             panic!("expected object");
+        }
+    }
+
+    #[test]
+    fn sleep_zero_and_epoch_millis_helpers_are_safe() {
+        assert_eq!(
+            call("time.sleep", vec![Value::Int(0)]).unwrap(),
+            Value::Null
+        );
+        for name in ["time.elapsed", "time.measure"] {
+            match call(name, vec![]).unwrap() {
+                Value::Int(n) => assert!(n > 0, "{name} should return epoch millis"),
+                other => panic!("expected int from {name}, got {other:?}"),
+            }
         }
     }
 
@@ -968,6 +1035,14 @@ mod tests {
         let t = call("time.from_unix", vec![Value::Int(0)]).unwrap();
         let result = call("time.start_of", vec![t, s("fortnight")]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn representative_wrong_arg_errors() {
+        assert!(call("time.zone", vec![Value::Int(0), Value::Int(1)]).is_err());
+        assert!(call("time.sleep", vec![s("0")]).is_err());
+        assert!(call("time.is_weekday", vec![s("not time")]).is_err());
+        assert!(call("time.day_of_week", vec![s("not time")]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds deterministic tests for remaining `time` exports including timezone conversion, local time shape, weekday/weekend helpers, zero sleep, and epoch-millis helpers.
- Adds small edge-case coverage for JSON non-string map key rejection, regex invalid pattern propagation, and crypto wrong-argument paths.

## Test plan
- [x] `cargo test stdlib::crypto --lib`
- [x] `cargo test stdlib::regex_module --lib`
- [x] `cargo test stdlib::json_module --lib`
- [x] `cargo test stdlib::time --lib`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded error validation test coverage across core standard library modules (crypto, JSON, regex, time).
  * Added comprehensive edge-case testing for input validation, error handling, and boundary conditions.

* **New Features**
  * Extended available functions in the time module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->