### PR TITLE
chore(vm): document cached closure invariant

### DIFF
--- a/.planning/unwrap-hot-path-sweep.plan.md
+++ b/.planning/unwrap-hot-path-sweep.plan.md
@@ -1,0 +1,30 @@
+# Unwrap Hot Path Sweep Plan
+
+## Goal
+
+Close production-readiness H1 by removing remaining production `unwrap()` usage in the scoped hot paths that can run while executing user programs.
+
+## Findings
+
+- `src/interpreter/mod.rs` has one `expect("BUG: channel mutex poisoned")`, already compliant with CLAUDE.md rule #6 because it documents an internal invariant.
+- `src/vm/machine.rs` has two `expect("BUG: ...")` calls, already compliant internal invariants.
+- `src/vm/machine.rs::run_until` still has `cached_closure.as_ref().unwrap()` in the VM execution loop.
+- `src/stdlib/*.rs` hits are in test modules, not production paths.
+
+## Implementation
+
+1. Replace `cached_closure.as_ref().unwrap()` in `VM::run_until` with `expect("BUG: cached_closure is None after need_fetch guard always fills it")`.
+   - This is a structural invariant inside the VM hot loop, not a recoverable user error.
+   - Avoid adding a dead `VMError` branch to the hottest execution path.
+2. Do not churn test `unwrap()` calls.
+3. Do not replace existing `expect("BUG: ...")` calls that already explain impossible internal invariants.
+
+## Tests
+
+- `cargo fmt`
+- `cargo test vm --lib`
+- `cargo test`
+
+## Rollback
+
+Restore the previous cached-closure unwrap. No serialization or runtime API changes involved.

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -1129,7 +1129,11 @@ impl VM {
                 };
                 cached_closure = Some((current_closure, c));
             }
-            let chunk = cached_closure.as_ref().unwrap().1.clone();
+            let chunk = cached_closure
+                .as_ref()
+                .expect("BUG: cached_closure is None after need_fetch guard always fills it")
+                .1
+                .clone();
 
             if self.frames[frame_idx].ip >= chunk.code.len() {
                 self.frames.pop();


### PR DESCRIPTION
## Summary
- Replaces the remaining production `unwrap()` in the VM hot loop with an explicit `BUG:` invariant `expect`.
- Captures the H1 unwrap sweep findings in a plan artifact without changing runtime behavior.

## Test plan
- [x] `cargo test vm --lib`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling robustness in the VM execution layer to strengthen production reliability and failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->