### PR TITLE
Record final production verification

### DIFF
--- a/.planning/PRODUCTION_READINESS.md
+++ b/.planning/PRODUCTION_READINESS.md
@@ -140,10 +140,10 @@ Every item must end with `cargo test` green at 697+ before commit.
 
 - `cargo test` (must remain ≥697)
 - `cargo build --release`
-- `forge test` (integration)
+- `forge --allow-run test` (integration; shell tests require explicit permission)
 - `forge run examples/hello.fg`, `examples/functional.fg`
-- `forge run --vm examples/hello.fg`
-- `forge run --jit examples/hello.fg`
+- `forge --vm run examples/hello.fg`
+- `forge --jit run examples/hello.fg`
 
 ---
 

--- a/.planning/final-verification-report.md
+++ b/.planning/final-verification-report.md
@@ -1,0 +1,18 @@
+# Final Verification Report
+
+Verified SHA: `3d9001ee2a948cab1d0ec9558f1677080a8a1a19`
+
+| Command | Status | Log |
+|---|---:|---|
+| `cargo test` | PASS | `/tmp/forge-h3-logs/cargo-test.log` |
+| `cargo build --release` | PASS | `/tmp/forge-h3-logs/cargo-build-release.log` |
+| `target/release/forge --allow-run test` | PASS | `/tmp/forge-h3-logs/forge-test-allow-run.log` |
+| `target/release/forge run examples/hello.fg` | PASS | `/tmp/forge-h3-logs/forge-run-hello.log` |
+| `target/release/forge run examples/functional.fg` | PASS | `/tmp/forge-h3-logs/forge-run-functional.log` |
+| `target/release/forge --vm run examples/hello.fg` | PASS | `/tmp/forge-h3-logs/forge-vm-hello.log` |
+| `target/release/forge --jit run examples/hello.fg` | PASS | `/tmp/forge-h3-logs/forge-jit-hello.log` |
+
+## Notes
+
+- Logs are stored under `/tmp/forge-h3-logs`.
+- `target/release/forge test` without `--allow-run` failed on 7 shell-execution tests with the expected permission error: `Shell execution denied. Use --allow-run to enable sh/shell/run_command.` The checklist now uses `--allow-run` for the integration suite because those tests intentionally exercise shell helpers.

--- a/.planning/final-verification.plan.md
+++ b/.planning/final-verification.plan.md
@@ -1,0 +1,40 @@
+# Final Verification Plan
+
+## Goal
+
+Close production-readiness H3 by running the final verification checklist after all preceding production-readiness items have merged.
+
+## Checklist
+
+Run from clean `main` on a verification branch:
+
+1. `cargo test`
+2. `cargo build --release`
+3. `target/release/forge --allow-run test`
+4. `target/release/forge run examples/hello.fg`
+5. `target/release/forge run examples/functional.fg`
+6. `target/release/forge --vm run examples/hello.fg`
+7. `target/release/forge --jit run examples/hello.fg`
+
+The release build uses the default Cargo feature set, which includes `jit`.
+The Forge integration suite includes shell-execution tests, so the explicit
+`--allow-run` permission flag is required. All commands must exit successfully;
+any `forge --allow-run test` failure is a blocker and should be recorded in the
+report instead of treated as a pass.
+
+## Artifact
+
+Create `.planning/final-verification-report.md` with:
+
+- command list
+- pass/fail result for each command
+- any warnings or skipped items
+- final git SHA verified
+
+## Tests
+
+The checklist is the test.
+
+## Rollback
+
+Remove the verification report and plan file if the verification PR should not be kept.


### PR DESCRIPTION
## Summary
- Records the final production-readiness verification checklist and passing release-build results.
- Corrects the checklist to use `forge --allow-run test` for integration tests that intentionally exercise shell helpers.
- Keeps the corrected top-level `--vm` / `--jit` CLI flag ordering in the production-readiness checklist.

## Test plan
- `cargo test`
- `cargo build --release`
- `target/release/forge --allow-run test`
- `target/release/forge run examples/hello.fg`
- `target/release/forge run examples/functional.fg`
- `target/release/forge --vm run examples/hello.fg`
- `target/release/forge --jit run examples/hello.fg`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated production readiness verification documentation to establish final verification processes and testing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->