### PR TITLE
Cover schedule handler isolation

### DIFF
--- a/.planning/schedule-handler-isolation-test.plan.md
+++ b/.planning/schedule-handler-isolation-test.plan.md
@@ -1,0 +1,38 @@
+# Schedule Handler Isolation Test Plan
+
+## Goal
+
+Close issue #109 by adding an integration regression test that locks in the documented Forge HTTP fork invariant: writes made by `schedule` / `watch` background runtimes must not leak into per-request handler forks.
+
+## Current State
+
+- `Environment::fork_for_background_runtime()` intentionally uses `deep_clone()` so recurring background jobs keep their own state across ticks.
+- `Environment::fork_for_serving()` intentionally uses `deep_clone_isolated()` so each HTTP request sees the template snapshot and gets isolated closure state.
+- `tests/server_concurrency.rs` already boots real Forge HTTP servers on ephemeral ports and polls `/ping` for readiness.
+- There are strong per-request parallelism tests, but no end-to-end server test proving scheduled background mutation remains invisible to handlers.
+
+## Implementation
+
+1. Add a focused test to `tests/server_concurrency.rs`.
+2. Reuse `spawn_test_server()` so the test runs the same lexer/parser/interpreter/server path as the existing server integration tests.
+3. Test program:
+   - top-level `let mut state = 0`
+   - `schedule every 1 seconds { state = state + 1; fs.write("__SENTINEL__", "ran") }`
+   - `@get("/read") fn read() -> Json { return { state } }`
+   - existing `/ping` route for readiness
+4. Generate a unique sentinel path under `std::env::temp_dir()` and replace `__SENTINEL__` in the program source before booting the server.
+5. After readiness, sleep long enough for at least one 1-second schedule tick, then assert the sentinel file exists. This proves the schedule actually ran, avoiding a vacuous pass where handlers see `state == 0` because the schedule never fired.
+6. Issue several `/read` requests and deserialize each response with `serde_json::Value`; assert `body["state"] == serde_json::json!(0)`.
+7. Keep the assertion about handler visibility, not exact schedule tick counts. The test should fail only if handler forks start sharing background runtime state.
+8. Document that the existing `spawn_test_server()` path leaves `Interpreter::defer_host_runtime` at its default `false`, so schedules start during `interp.run()`. This differs from the production `main.rs` orchestration path but exercises the same background-runtime vs serving-fork semantics needed for this regression.
+
+## Tests
+
+- `cargo fmt`
+- `cargo test --test server_concurrency schedule_mutations_do_not_leak_into_handler_forks`
+- `cargo test --test server_concurrency`
+- `cargo test`
+
+## Rollback
+
+Remove the added integration test and this plan file. No runtime behavior changes expected.

--- a/.planning/schedule-handler-isolation-test.plan.md
+++ b/.planning/schedule-handler-isolation-test.plan.md
@@ -18,7 +18,7 @@ Close issue #109 by adding an integration regression test that locks in the docu
 3. Test program:
    - top-level `let mut state = 0`
    - `schedule every 1 seconds { state = state + 1; fs.write("__SENTINEL__", "ran") }`
-   - `@get("/read") fn read() -> Json { return { state } }`
+   - `@get("/read") fn read() -> Json { return { state: state } }`
    - existing `/ping` route for readiness
 4. Generate a unique sentinel path under `std::env::temp_dir()` and replace `__SENTINEL__` in the program source before booting the server.
 5. After readiness, sleep long enough for at least one 1-second schedule tick, then assert the sentinel file exists. This proves the schedule actually ran, avoiding a vacuous pass where handlers see `state == 0` because the schedule never fired.

--- a/tests/server_concurrency.rs
+++ b/tests/server_concurrency.rs
@@ -23,7 +23,7 @@ use forge_lang::runtime::server::start_server;
 
 use std::net::TcpListener;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Pick an unused TCP port by binding 0 and letting the kernel choose.
 fn pick_port() -> u16 {
@@ -239,6 +239,81 @@ fn closure_capturing_handlers_run_in_parallel_not_serialized() {
         single,
         parallel.as_secs_f64() / single.as_secs_f64()
     );
+}
+
+#[test]
+fn schedule_mutations_do_not_leak_into_handler_forks() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let sentinel = std::env::temp_dir().join(format!(
+        "forge_schedule_handler_isolation_{}_{}.txt",
+        std::process::id(),
+        unique
+    ));
+    let _ = std::fs::remove_file(&sentinel);
+    let sentinel_str = sentinel
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // `spawn_test_server` leaves `defer_host_runtime` at the Interpreter default
+    // (`false`), so schedules start during `interp.run()`. That differs from the
+    // CLI orchestration path but exercises the same background-runtime vs
+    // per-request serving-fork isolation contract.
+    let source = r#"
+        @server(port: __PORT__)
+
+        let mut state = 0
+
+        schedule every 1 seconds {
+            state = state + 1
+            fs.write("__SENTINEL__", "ran")
+        }
+
+        @get("/ping")
+        fn ping() -> Json {
+            return { ok: true }
+        }
+
+        @get("/read")
+        fn read() -> Json {
+            return { state: state }
+        }
+        "#
+    .replace("__SENTINEL__", &sentinel_str);
+
+    let port = spawn_test_server(&source);
+    std::thread::sleep(Duration::from_millis(1500));
+
+    assert!(
+        sentinel.exists(),
+        "schedule body never wrote sentinel file at {}; test would be vacuous",
+        sentinel.display()
+    );
+
+    let url = format!("http://127.0.0.1:{}/read", port);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+
+    for attempt in 0..5 {
+        let body: serde_json::Value = client
+            .get(&url)
+            .send()
+            .expect("send")
+            .json()
+            .expect("json response");
+        assert_eq!(
+            body["state"],
+            serde_json::json!(0),
+            "handler fork observed background schedule mutation on attempt {attempt}: {body}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&sentinel);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds a server integration regression test for issue #109 proving scheduled background mutations do not leak into HTTP handler forks.
- Proves the schedule actually ran via a sentinel file, then asserts repeated `/read` JSON responses still see the template snapshot.
- Documents the approved test plan and the `defer_host_runtime` behavior used by the existing server test helper.

Closes #109.

## Test plan
- `cargo fmt`
- `cargo test --test server_concurrency schedule_mutations_do_not_leak_into_handler_forks`
- `cargo test --test server_concurrency`
- `cargo test`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify request handlers remain isolated from background task mutations, ensuring system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->